### PR TITLE
#343 Fix

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -54,9 +54,9 @@ export const handle = async ({ event, resolve }) => {
 
 	// ---- Detect available LLM providers based on API keys ----
 	const availableProviders = []
-	if (env.OPENAI_API_KEY || env.LLM_API_KEY) availableProviders.push('openai')
+	if (env.OPENAI_API_KEY) availableProviders.push('openai')
 	if (env.ANTHROPIC_API_KEY) availableProviders.push('anthropic')
-	if (env.GOOGLE_API_KEY || env.GEMINI_API_KEY) availableProviders.push('google')
+	if (env.GOOGLE_API_KEY) availableProviders.push('google')
 	if (env.OLLAMA_BASE_URL) availableProviders.push('ollama')
 
 	const hasAnyApiKey = availableProviders.length > 0

--- a/src/lib/server/aiHelpers.js
+++ b/src/lib/server/aiHelpers.js
@@ -1,0 +1,43 @@
+import { jsonError } from '$lib/server/authHelpers'
+
+/**
+ * Resolve effective AI provider/model for an API request from hook-populated locals.
+ *
+ * @param {import('@sveltejs/kit').RequestEvent['locals']} locals
+ * @param {'text' | 'image'} [type='text']
+ * @returns {{ ok: true, provider: string, model: string | null } | { ok: false, response: Response }}
+ */
+export function resolveAIConfig(locals, type = 'text') {
+	const ai = locals?.site?.ai
+
+	if (!ai?.enabled) {
+		return { ok: false, response: jsonError(503, 'AI features are disabled.') }
+	}
+
+	const provider = ai.provider
+	if (!provider) {
+		return { ok: false, response: jsonError(500, 'No AI provider configured.') }
+	}
+
+	const availableProviders = ai.availableProviders || []
+	if (!availableProviders.includes(provider)) {
+		return {
+			ok: false,
+			response: jsonError(
+				503,
+				`Selected AI provider "${provider}" is not configured in the environment.`
+			)
+		}
+	}
+
+	if (type === 'image' && provider === 'ollama') {
+		return {
+			ok: false,
+			response: jsonError(400, 'Selected AI provider does not support image parsing.')
+		}
+	}
+
+	const model = type === 'image' ? ai.imageModel || ai.textModel || null : ai.textModel || null
+
+	return { ok: true, provider, model }
+}

--- a/src/lib/utils/ai.js
+++ b/src/lib/utils/ai.js
@@ -189,11 +189,10 @@ ${recipeJson}
  * @returns {Promise<import('@langchain/core/language_models/chat_models').BaseChatModel>}
  */
 function resolveApiKey(provider) {
-	const generic = env.LLM_API_KEY
-	if (provider === 'openai') return env.OPENAI_API_KEY || generic
-	if (provider === 'anthropic') return env.ANTHROPIC_API_KEY || generic
-	if (provider === 'google') return env.GOOGLE_API_KEY || generic
-	return generic
+	if (provider === 'openai') return env.OPENAI_API_KEY
+	if (provider === 'anthropic') return env.ANTHROPIC_API_KEY
+	if (provider === 'google') return env.GOOGLE_API_KEY
+	return undefined
 }
 
 function makeProviderLoader({ provider, importPath, clientName, buildConfig }) {
@@ -272,9 +271,11 @@ async function invokeLLM({ provider, model, type, messages }) {
 	if (env.LLM_API_ENABLED !== 'true') throw new Error('LLM API is disabled')
 
 	const defaultProvider = env.LLM_PROVIDER || 'openai'
-	const effectiveProvider = provider || (type === 'image' ?
-		(env.LLM_IMAGE_PROVIDER || env.LLM_TEXT_PROVIDER || defaultProvider) :
-		(env.LLM_TEXT_PROVIDER || defaultProvider))
+	const effectiveProvider =
+		provider ||
+		(type === 'image'
+			? env.LLM_IMAGE_PROVIDER || env.LLM_TEXT_PROVIDER || defaultProvider
+			: env.LLM_TEXT_PROVIDER || defaultProvider)
 
 	const defaultTextModel = env.LLM_TEXT_MODEL || env.LLM_API_ENGINE_TEXT || 'gpt-3.5-turbo'
 	const defaultImageModel = env.LLM_IMAGE_MODEL || env.LLM_API_ENGINE_IMAGE || 'gpt-4o'
@@ -323,7 +324,9 @@ async function invokeLLM({ provider, model, type, messages }) {
 
 				// Find the last complete value (ends with ", or ", or ], or number, or true/false/null)
 				// Look for last occurrence of a complete JSON value followed by comma or end
-				const lastCompleteMatch = output.match(/^([\s\S]*(?:"\s*,|"\s*$|\]\s*,|\]\s*$|\d\s*,|\d\s*$|true\s*,|true\s*$|false\s*,|false\s*$|null\s*,|null\s*$))/);
+				const lastCompleteMatch = output.match(
+					/^([\s\S]*(?:"\s*,|"\s*$|\]\s*,|\]\s*$|\d\s*,|\d\s*$|true\s*,|true\s*$|false\s*,|false\s*$|null\s*,|null\s*$))/
+				)
 
 				if (lastCompleteMatch) {
 					output = lastCompleteMatch[1].trim()

--- a/src/routes/api/recipe/cleanup/+server.js
+++ b/src/routes/api/recipe/cleanup/+server.js
@@ -1,8 +1,14 @@
 import { generateRecipeWithLLM } from '$lib/utils/ai'
 import { json } from '@sveltejs/kit'
+import { resolveAIConfig } from '$lib/server/aiHelpers'
 
-export async function POST({ request }) {
+export async function POST({ request, locals }) {
 	try {
+		const aiConfig = resolveAIConfig(locals, 'text')
+		if (!aiConfig.ok) {
+			return aiConfig.response
+		}
+
 		const { type, content, userUnits = 'metric', language = 'eng' } = await request.json()
 
 		if (!type || !content) {
@@ -86,6 +92,8 @@ Return format:
 		// Use generateRecipeWithLLM for cleanup task
 		const response = await generateRecipeWithLLM({
 			prompt,
+			provider: aiConfig.provider,
+			model: aiConfig.model || undefined,
 			unitsPreference: userUnits,
 			language
 		})

--- a/src/routes/api/recipe/parse/+server.js
+++ b/src/routes/api/recipe/parse/+server.js
@@ -1,8 +1,14 @@
 import { extractRecipeWithLLM, generateRecipeWithLLM } from '$lib/utils/ai'
 import { json } from '@sveltejs/kit'
+import { resolveAIConfig } from '$lib/server/aiHelpers'
 
-export async function POST({ request }) {
+export async function POST({ request, locals }) {
 	try {
+		const aiConfig = resolveAIConfig(locals, 'text')
+		if (!aiConfig.ok) {
+			return aiConfig.response
+		}
+
 		const { text, mode = 'parse', unitsPreference, language = 'eng' } = await request.json()
 
 		if (!text || typeof text !== 'string') {
@@ -13,10 +19,14 @@ export async function POST({ request }) {
 			mode === 'prompt'
 				? await generateRecipeWithLLM({
 						prompt: text,
+						provider: aiConfig.provider,
+						model: aiConfig.model || undefined,
 						unitsPreference,
 						language
 					})
 				: await extractRecipeWithLLM({
+						provider: aiConfig.provider,
+						model: aiConfig.model || undefined,
 						type: 'text',
 						content: text,
 						language

--- a/src/routes/api/recipe/parse/image/+server.js
+++ b/src/routes/api/recipe/parse/image/+server.js
@@ -2,8 +2,14 @@ import { extractRecipeWithLLM } from '$lib/utils/ai'
 import { fileTypeFromBuffer } from 'file-type'
 import { json } from '@sveltejs/kit'
 import { resizeImageBuffer, stitchImages } from '$lib/utils/image/imageBackend'
+import { resolveAIConfig } from '$lib/server/aiHelpers'
 
-export async function POST({ request }) {
+export async function POST({ request, locals }) {
+	const aiConfig = resolveAIConfig(locals, 'image')
+	if (!aiConfig.ok) {
+		return aiConfig.response
+	}
+
 	const formData = await request.formData()
 	const files = formData.getAll('image')
 	const language = formData.get('language') || 'eng'
@@ -37,7 +43,8 @@ export async function POST({ request }) {
 				: await stitchImages(processedBuffers, { padding: 12, maxWidth: 1400 })
 
 		const recipe = await extractRecipeWithLLM({
-			provider: 'openai',
+			provider: aiConfig.provider,
+			model: aiConfig.model || undefined,
 			type: 'image',
 			imageBuffer: stitchedBuffer,
 			imageMimeType: 'image/png',

--- a/src/routes/api/recipe/scrape/[url]/+server.js
+++ b/src/routes/api/recipe/scrape/[url]/+server.js
@@ -1,11 +1,8 @@
 import { parseURL } from '$lib/utils/parse/recipeParse'
 import { extractRecipeWithLLM } from '$lib/utils/ai'
-import { env } from '$env/dynamic/private'
+import { resolveAIConfig } from '$lib/server/aiHelpers'
 
-const OPENAI_API_KEY = env.OPENAI_API_KEY || 'sk-xxxxxxxxxxxxxxxxxxxxxxxxx'
-const LLM_API_ENABLED = env.LLM_API_ENABLED || 'false'
-
-export async function GET({ params }) {
+export async function GET({ params, locals }) {
 	const url = decodeURIComponent(params.url)
 	let scrapedRecipe = null
 	let html = ''
@@ -32,25 +29,31 @@ export async function GET({ params }) {
 	}
 
 	// AI fallback
-	if (OPENAI_API_KEY && html && LLM_API_ENABLED) {
+	if (html) {
 		console.log('Attempting AI scrape...')
 		try {
-			const aiRecipe = await extractRecipeWithLLM({
-				provider: 'openai',
-				type: 'html',
-				content: html,
-				url
-			})
-			if (
-				aiRecipe &&
-				typeof aiRecipe === 'object' &&
-				aiRecipe.name &&
-				aiRecipe.ingredients?.length > 0
-			) {
-				console.log('AI scrape success.')
-				return jsonResponse({ ...aiRecipe, _source: 'AI', _status: 'complete' }, 200)
+			const aiConfig = resolveAIConfig(locals, 'text')
+			if (!aiConfig.ok) {
+				console.warn('AI scrape skipped: AI is unavailable for this request.')
 			} else {
-				console.warn('AI scrape incomplete, returning partial regular scrape.')
+				const aiRecipe = await extractRecipeWithLLM({
+					provider: aiConfig.provider,
+					model: aiConfig.model || undefined,
+					type: 'html',
+					content: html,
+					url
+				})
+				if (
+					aiRecipe &&
+					typeof aiRecipe === 'object' &&
+					aiRecipe.name &&
+					aiRecipe.ingredients?.length > 0
+				) {
+					console.log('AI scrape success.')
+					return jsonResponse({ ...aiRecipe, _source: 'AI', _status: 'complete' }, 200)
+				} else {
+					console.warn('AI scrape incomplete, returning partial regular scrape.')
+				}
 			}
 		} catch (aiErr) {
 			console.error('AI scrape failed:', aiErr)

--- a/src/routes/api/recipe/translate/+server.js
+++ b/src/routes/api/recipe/translate/+server.js
@@ -1,15 +1,27 @@
 import { translateRecipeWithLLM } from '$lib/utils/ai'
 import { json } from '@sveltejs/kit'
+import { resolveAIConfig } from '$lib/server/aiHelpers'
 
-export async function POST({ request }) {
+export async function POST({ request, locals }) {
 	try {
+		const aiConfig = resolveAIConfig(locals, 'text')
+		if (!aiConfig.ok) {
+			return aiConfig.response
+		}
+
 		const { recipe, language = 'eng', fromLanguage = null } = await request.json()
 
 		if (!recipe || typeof recipe !== 'object') {
 			return json({ error: 'Missing recipe.' }, { status: 400 })
 		}
 
-		const response = await translateRecipeWithLLM({ recipe, language, fromLanguage })
+		const response = await translateRecipeWithLLM({
+			recipe,
+			provider: aiConfig.provider,
+			model: aiConfig.model || undefined,
+			language,
+			fromLanguage
+		})
 
 		if (!response || typeof response !== 'object') {
 			return json({ error: 'Translation failed - invalid response format.' }, { status: 422 })


### PR DESCRIPTION
- Fixed provider selection bug so AI parsing no longer defaults to OpenAI when another provider is chosen in Site Settings.
- Added _aiHelpers.js_ to centralize route-level AI config (enabled state, provider availability, model selection, image support).
- Updated all AI recipe endpoints (scrape, parse, parse/image, cleanup, translate) to use provider/model from _locals.site.ai_
- Removed hardcoded OpenAI usage in scrape/image flows and improved behavior for unavailable AI fallback.
- Removed generic/legacy key fallback paths; _ai.js_ now resolves only provider-specific keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY).