### PR TITLE
tidying up the slop, adding some new stuff, ui tweaks

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -65,11 +65,6 @@ ORIGIN=http://localhost:3000
 # Ollama (local models) - only set if not using default localhost
 # OLLAMA_BASE_URL=http://localhost:11434
 
-# Semantic Search (disabled by default)
-# Requires OPENAI_API_KEY or OLLAMA_BASE_URL
-# SEMANTIC_SEARCH_ENABLED=false
-# EMBEDDING_PROVIDER=openai  # or ollama (auto-detect if omitted)
-# EMBEDDING_MODEL=nomic-embed-text
 # Optional startup warmup (leave false to avoid startup overhead)
 # SEMANTIC_WARMUP_ON_BOOT=false
 

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -228,9 +228,23 @@ Semantic search is optional and **admin-controlled**. Users do not need to toggl
 
 1. Add a supported embedding provider in `.env`:
    - `OPENAI_API_KEY` or
-   - `OLLAMA_BASE_URL` (and optional embedding model)
-2. Set `SEMANTIC_SEARCH_ENABLED=true` in `.env`
-3. In **Options > Site** (admin), enable semantic search.
+   - `GOOGLE_API_KEY` (Gemini embeddings) or
+   - `OLLAMA_BASE_URL`
+2. In **Options > Site** (admin), enable semantic search.
+3. In **Options > Site** (admin), select embedding provider/model.
+
+#### Cost note
+
+- Search-time embedding sends only the query text (for example, `"Japanese"`), not your full recipe database.
+- Ballpark with OpenAI `text-embedding-3-small` pricing (~$0.02 per 1M input tokens):
+  - **1,000 searches** (short queries): roughly **<$0.001** (typically around $0.0001-$0.0004)
+  - **Embedding 1,000 recipes** (one-time index): roughly **$0.01-$0.04** depending on recipe length
+- With Ollama, there is no per-request API billing; cost is local CPU/RAM usage.
+- Ollama embedding model suggestions:
+  - `embeddinggemma` (good default)
+  - `qwen3-embedding` (strong quality option)
+  - `all-minilm` (lightweight/fast)
+- Prices can change over time, so treat these as approximate figures.
 
 #### Build Embedding Index
 

--- a/prisma/migrations/20260214094000_add_llm_image_provider/migration.sql
+++ b/prisma/migrations/20260214094000_add_llm_image_provider/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "SiteSettings" ADD COLUMN "llmImageProvider" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -210,10 +210,11 @@ model SiteSettings {
   // LLM Configuration
   llmEnabled          Boolean @default(false)
   llmProvider         String? // Default provider: 'openai' | 'anthropic' | 'google' | 'ollama'
+  llmImageProvider    String? // Optional separate provider for image parsing
   llmTextModel        String? // Model for text parsing
   llmImageModel       String? // Model for image parsing
   semanticEnabled     Boolean @default(false)
-  semanticEmbeddingProvider String? // Embedding provider: 'openai' | 'ollama'
+  semanticEmbeddingProvider String? // Embedding provider: 'openai' | 'google' | 'ollama'
   semanticEmbeddingModel String? // Embedding model override
 }
 

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -5,8 +5,12 @@ import { dbSeeded } from '$lib/utils/seed/seedHelpers'
 import { env } from '$env/dynamic/private'
 import { getClientIp, makeLimiter } from '$lib/server/rateLimit'
 import { redirect } from '@sveltejs/kit'
-import { resolveEmbeddingProvider } from '$lib/utils/embeddings'
-import { getAvailableAiProviders, resolveProviderSelection } from '$lib/utils/llmModels'
+import {
+	getAvailableAiProviders,
+	getAvailableEmbeddingProviders,
+	resolveEmbeddingProvider,
+	resolveProviderSelection
+} from '$lib/utils/llmModels'
 
 const envTrue = (v) => typeof v === 'string' && /^(true|1|yes|on)$/i.test(v.trim())
 
@@ -76,8 +80,8 @@ export const handle = async ({ event, resolve }) => {
 		// Only enabled if DB says so AND we have API keys
 		const llmEnabled = hasAnyApiKey && (s?.llmEnabled ?? envTrue(env.LLM_API_ENABLED))
 
-		// Provider: DB/env preference, but fall back to any configured provider
-		// when the preferred one is unavailable (e.g. OpenAI selected but only Anthropic key exists).
+		// Text provider: DB/env preference, but fall back to any configured provider
+		// when the preferred one is unavailable.
 		const preferredProvider = s?.llmProvider || env.LLM_PROVIDER || null
 		const {
 			provider: llmProvider,
@@ -97,11 +101,32 @@ export const handle = async ({ event, resolve }) => {
 			}
 		}
 
-		// Models: use configured values only when provider preference is still valid.
-		// If we had to auto-fallback providers, clear models to let provider defaults apply.
+		// Image provider: optional separate provider, falling back to text provider preference.
+		const preferredImageProvider = s?.llmImageProvider || preferredProvider
+		const {
+			provider: llmImageProvider,
+			selectedProvider: selectedImageProvider,
+			selectedProviderConfigured: selectedImageProviderConfigured
+		} = resolveProviderSelection(preferredImageProvider, availableProviders)
+
+		if (selectedImageProvider && !selectedImageProviderConfigured) {
+			if (llmImageProvider) {
+				console.warn(
+					`AI image provider "${selectedImageProvider}" is selected but not configured in environment. Falling back to "${llmImageProvider}".`
+				)
+			} else {
+				console.warn(
+					`AI image provider "${selectedImageProvider}" is selected but not configured in environment, and no fallback provider is available.`
+				)
+			}
+		}
+
+		// Models: use configured values only when preferred provider is still valid.
 		const usingPreferredProvider = llmProvider && llmProvider === preferredProvider
+		const usingPreferredImageProvider =
+			llmImageProvider && llmImageProvider === preferredImageProvider
 		const textModel = usingPreferredProvider ? s?.llmTextModel || env.LLM_TEXT_MODEL || null : null
-		const imageModel = usingPreferredProvider
+		const imageModel = usingPreferredImageProvider
 			? s?.llmImageModel || env.LLM_IMAGE_MODEL || null
 			: null
 
@@ -112,29 +137,26 @@ export const handle = async ({ event, resolve }) => {
 			provider: llmProvider,
 			selectedProvider,
 			selectedProviderConfigured,
+			imageProvider: llmImageProvider,
+			selectedImageProvider,
+			selectedImageProviderConfigured,
 			textModel,
 			imageModel,
-			imageAllowed: llmProvider !== 'ollama'
+			imageAllowed: !!llmImageProvider && llmImageProvider !== 'ollama'
 		}
 
 		// Semantic config:
-		// - env flag is hard capability gate
-		// - site setting (when present) can disable it at runtime
-		// - provider currently supported: OpenAI embeddings or Ollama embeddings
-		const semanticEnabledByEnv = envTrue(env.SEMANTIC_SEARCH_ENABLED)
-		const semanticProviderOptions = []
-		if (env.OPENAI_API_KEY) semanticProviderOptions.push('openai')
-		if (env.OLLAMA_BASE_URL) semanticProviderOptions.push('ollama')
-		const preferredSemanticProvider =
-			s?.semanticEmbeddingProvider || env.EMBEDDING_PROVIDER || llmProvider || null
-		const semanticProvider = resolveEmbeddingProvider(preferredSemanticProvider)
+		// - site setting controls runtime enablement
+		// - provider availability controls whether semantic can run
+		const semanticProviderOptions = getAvailableEmbeddingProviders(env)
+		const preferredSemanticProvider = s?.semanticEmbeddingProvider || llmProvider || null
+		const semanticProvider = resolveEmbeddingProvider(preferredSemanticProvider, env)
 		const semanticProviderAvailable = !!semanticProvider
 		const semanticEnabledBySite = s?.semanticEnabled ?? false
-		const semanticEmbeddingModel = s?.semanticEmbeddingModel || env.EMBEDDING_MODEL || null
+		const semanticEmbeddingModel = s?.semanticEmbeddingModel || null
 
 		semantic = {
-			enabled: semanticEnabledByEnv && semanticProviderAvailable && semanticEnabledBySite,
-			enabledByEnv: semanticEnabledByEnv,
+			enabled: semanticProviderAvailable && semanticEnabledBySite,
 			enabledBySite: semanticEnabledBySite,
 			providerAvailable: semanticProviderAvailable,
 			provider: semanticProvider,
@@ -158,20 +180,22 @@ export const handle = async ({ event, resolve }) => {
 			provider: null,
 			selectedProvider: null,
 			selectedProviderConfigured: false,
+			imageProvider: null,
+			selectedImageProvider: null,
+			selectedImageProviderConfigured: false,
 			textModel: null,
 			imageModel: null,
 			imageAllowed: false
 		}
 		semantic = {
 			enabled: false,
-			enabledByEnv: envTrue(env.SEMANTIC_SEARCH_ENABLED),
 			enabledBySite: false,
-			providerAvailable: !!resolveEmbeddingProvider(null),
-			provider: resolveEmbeddingProvider(null),
+			providerAvailable: !!resolveEmbeddingProvider(null, env),
+			provider: resolveEmbeddingProvider(null, env),
 			availableProviders: [],
 			selectedProvider: null,
 			selectedProviderConfigured: false,
-			model: env.EMBEDDING_MODEL || null
+			model: null
 		}
 	}
 

--- a/src/lib/components/recipe/RecipeFeed.svelte
+++ b/src/lib/components/recipe/RecipeFeed.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { goto, invalidateAll } from '$app/navigation'
-	import { navigating } from '$app/stores'
+	import { navigating } from '$app/state'
 	import { sortByDate, sortByKeyGeneric } from '$lib/utils/sorting'
 	import RecipeFilter from '$lib/components/recipe/RecipeFilter.svelte'
 	import RecipeList from '$lib/components/recipe/RecipeList.svelte'
@@ -43,8 +43,8 @@
 	let pendingCopyUid = $state(null)
 	let copyMessage = $state(null)
 	let semanticScores = $state(new Map())
-	let semanticPending = $state(false)
 	let semanticRuntimeEnabled = $state(!!semanticEnabled)
+	let isNavigating = $derived(!!navigating?.to)
 
 	function includesQueryAcrossRecipe(recipe, query) {
 		const q = query?.toLowerCase?.().trim?.()
@@ -347,16 +347,14 @@
 		if (
 			!semanticRuntimeEnabled ||
 			!$searchString ||
-			$searchString.length < 3 ||
+			$searchString.length < 4 ||
 			($searchFields || []).length > 0
 		) {
 			semanticScores = new Map()
-			semanticPending = false
 			return
 		}
 
 		const timeout = setTimeout(async () => {
-			semanticPending = true
 			try {
 				const response = await fetch(
 					`/api/recipe/search?q=${encodeURIComponent($searchString)}&mode=semantic&limit=80`
@@ -378,10 +376,8 @@
 			} catch (error) {
 				console.error('Semantic search request failed:', error)
 				semanticScores = new Map()
-			} finally {
-				semanticPending = false
 			}
-		}, 300)
+		}, 500)
 
 		return () => clearTimeout(timeout)
 	})
@@ -440,7 +436,7 @@
 	class:max-md:ml-0={sidebarOpen}
 >
 	<RecipeFilter {toggleSidebar} viewOnly={false} {useCats} username={ownerUsername} {viewMode} />
-	<Spinner visible={isLoading || !!$navigating || semanticPending} spinnerContent="Loading" />
+	<Spinner visible={isLoading || isNavigating} spinnerContent="Loading" />
 	<RecipeList
 		{filteredRecipes}
 		{viewMode}

--- a/src/lib/components/ui/DropdownMenu.svelte
+++ b/src/lib/components/ui/DropdownMenu.svelte
@@ -1,4 +1,6 @@
 <script>
+	import { onMount } from 'svelte'
+
 	/** @type {{align?: 'start' | 'end', summaryClass?: string, summaryAriaLabel?: string, contentClass?: string, trigger?: import('svelte').Snippet, children?: import('svelte').Snippet}} */
 	let {
 		align = 'end',
@@ -8,9 +10,22 @@
 		trigger,
 		children
 	} = $props()
+
+	let root
+
+	onMount(() => {
+		const handlePointerDown = (event) => {
+			if (!root?.open) return
+			if (root.contains(event.target)) return
+			root.open = false
+		}
+
+		document.addEventListener('pointerdown', handlePointerDown)
+		return () => document.removeEventListener('pointerdown', handlePointerDown)
+	})
 </script>
 
-<details class={`dropdown dropdown-${align}`}>
+<details bind:this={root} class={`dropdown dropdown-${align}`}>
 	<summary class={summaryClass} aria-label={summaryAriaLabel}>
 		{#if trigger}
 			{@render trigger()}

--- a/src/lib/server/aiHelpers.js
+++ b/src/lib/server/aiHelpers.js
@@ -14,9 +14,12 @@ export function resolveAIConfig(locals, type = 'text') {
 		return { ok: false, response: jsonError(503, 'AI features are disabled.') }
 	}
 
-	const provider = ai.provider
+	const provider = type === 'image' ? ai.imageProvider || ai.provider : ai.provider
 	if (!provider) {
-		return { ok: false, response: jsonError(500, 'No AI provider configured.') }
+		return {
+			ok: false,
+			response: jsonError(500, `No AI ${type} provider configured.`)
+		}
 	}
 
 	const availableProviders = ai.availableProviders || []
@@ -37,7 +40,7 @@ export function resolveAIConfig(locals, type = 'text') {
 		}
 	}
 
-	const model = type === 'image' ? ai.imageModel || ai.textModel || null : ai.textModel || null
+	const model = type === 'image' ? ai.imageModel || null : ai.textModel || null
 
 	return { ok: true, provider, model }
 }

--- a/src/lib/server/semanticEmbedding.js
+++ b/src/lib/server/semanticEmbedding.js
@@ -1,24 +1,8 @@
 import { prisma } from '$lib/server/prisma'
+import { semanticEmbeddingJobsEnabled } from '$lib/server/semanticHelpers'
 import { env } from '$env/dynamic/private'
-import {
-	getEmbedding,
-	prepareRecipeText,
-	serializeEmbedding,
-	resolveEmbeddingProvider,
-	resolveEmbeddingModel
-} from '$lib/utils/embeddings'
-
-const envTrue = (v) => typeof v === 'string' && /^(true|1|yes|on)$/i.test(v.trim())
-
-/**
- * Check whether semantic embedding jobs should run.
- *
- * @returns {boolean}
- */
-export function semanticEmbeddingJobsEnabled(preferredProvider = null) {
-	if (!envTrue(env.SEMANTIC_SEARCH_ENABLED)) return false
-	return !!resolveEmbeddingProvider(preferredProvider)
-}
+import { resolveEmbeddingProvider, resolveEmbeddingModel } from '$lib/utils/llmModels'
+import { getEmbedding, prepareRecipeText, serializeEmbedding } from '$lib/utils/embeddings'
 
 /**
  * Regenerate embedding for a single recipe by uid.
@@ -54,7 +38,7 @@ export async function regenerateRecipeEmbedding(
 	const embedding = await getEmbedding(text, preferredProvider, preferredModel)
 	if (!embedding) return false
 
-	const provider = resolveEmbeddingProvider(preferredProvider)
+	const provider = resolveEmbeddingProvider(preferredProvider, env)
 	if (!provider) return false
 
 	await prisma.recipe.update({

--- a/src/lib/server/semanticHelpers.js
+++ b/src/lib/server/semanticHelpers.js
@@ -1,12 +1,23 @@
 import { jsonError } from '$lib/server/authHelpers'
+import { env } from '$env/dynamic/private'
+import { resolveEmbeddingProvider } from '$lib/utils/llmModels'
+
+/**
+ * Check whether semantic embedding jobs should run.
+ *
+ * @param {string | null} [preferredProvider=null]
+ * @returns {boolean}
+ */
+export function semanticEmbeddingJobsEnabled(preferredProvider = null) {
+	return !!resolveEmbeddingProvider(preferredProvider, env)
+}
 
 /**
  * Resolve semantic-search availability for a request.
  *
  * Semantic search is enabled only when:
- * 1. Env capability is enabled
- * 2. Provider capability exists
- * 3. Site-level setting allows it
+ * 1. Provider capability exists
+ * 2. Site-level setting allows it
  *
  * @param {import('@sveltejs/kit').RequestEvent['locals']} locals
  * @returns {{ enabled: true } | { enabled: false, reason: string, response: Response }}

--- a/src/lib/utils/ai.js
+++ b/src/lib/utils/ai.js
@@ -1,6 +1,7 @@
 import { HumanMessage, SystemMessage } from '@langchain/core/messages'
 import { env } from '$env/dynamic/private'
 import { languageLabels } from '$lib/submodules/recipe-ingredient-parser/src/i18n'
+import { getDefaultModelsForProvider } from '$lib/utils/llmModels'
 
 /**
  * Map of measurement system codes to human-readable descriptions for AI prompts
@@ -263,25 +264,6 @@ async function loadChatClient(provider, model, type) {
 	return loader(model, type)
 }
 
-const providerDefaultModels = {
-	openai: {
-		text: 'gpt-4o-mini',
-		image: 'gpt-4o-mini'
-	},
-	anthropic: {
-		text: 'claude-3-5-haiku-20241022',
-		image: 'claude-3-5-sonnet-20241022'
-	},
-	google: {
-		text: 'gemini-2.0-flash',
-		image: 'gemini-2.0-flash'
-	},
-	ollama: {
-		text: 'llama3.2',
-		image: null
-	}
-}
-
 /**
  * Core LLM invocation function - builds messages and calls the model
  * @private
@@ -294,14 +276,23 @@ async function invokeLLM({ provider, model, type, messages }) {
 			? env.LLM_IMAGE_PROVIDER || env.LLM_TEXT_PROVIDER || defaultProvider
 			: env.LLM_TEXT_PROVIDER || defaultProvider)
 
-	const providerDefaults = providerDefaultModels[effectiveProvider] || providerDefaultModels.openai
+	// Get default models from centralized catalog
+	const providerDefaults = getDefaultModelsForProvider(effectiveProvider)
+	const fallbackDefaults = getDefaultModelsForProvider('openai')
+
 	const defaultTextModel =
-		env.LLM_TEXT_MODEL || env.LLM_API_ENGINE_TEXT || providerDefaults.text || 'gpt-4o-mini'
+		env.LLM_TEXT_MODEL ||
+		env.LLM_API_ENGINE_TEXT ||
+		providerDefaults.text ||
+		fallbackDefaults.text ||
+		'gpt-4o-mini'
 	const defaultImageModel =
 		env.LLM_IMAGE_MODEL ||
 		env.LLM_API_ENGINE_IMAGE ||
 		providerDefaults.image ||
-		providerDefaults.text
+		providerDefaults.text ||
+		fallbackDefaults.image ||
+		fallbackDefaults.text
 	const effectiveModel = model || (type === 'image' ? defaultImageModel : defaultTextModel)
 
 	if (type === 'image' && effectiveProvider === 'ollama') {

--- a/src/lib/utils/embeddings.js
+++ b/src/lib/utils/embeddings.js
@@ -1,48 +1,5 @@
 import { env } from '$env/dynamic/private'
-
-const OPENAI_DEFAULT_MODEL = 'text-embedding-3-small'
-const OLLAMA_DEFAULT_MODEL = 'nomic-embed-text'
-
-/**
- * Resolve embedding provider from environment.
- *
- * Precedence:
- * 1. EMBEDDING_PROVIDER env override (openai|ollama)
- * 2. Preferred provider (from runtime settings) if supported and configured
- *
- * No silent fallback when a preferred provider is provided but unsupported/unconfigured.
- *
- * @param {string | null} [preferredProvider=null]
- * @returns {'openai' | 'ollama' | null}
- */
-export function resolveEmbeddingProvider(preferredProvider = null) {
-	const forced = (env.EMBEDDING_PROVIDER || '').trim().toLowerCase()
-	if (forced === 'openai' && env.OPENAI_API_KEY) return 'openai'
-	if (forced === 'ollama' && env.OLLAMA_BASE_URL) return 'ollama'
-
-	const preferred = (preferredProvider || '').trim().toLowerCase()
-	if (preferred) {
-		if (preferred === 'openai' && env.OPENAI_API_KEY) return 'openai'
-		if (preferred === 'ollama' && env.OLLAMA_BASE_URL) return 'ollama'
-		return null
-	}
-
-	if (env.OPENAI_API_KEY) return 'openai'
-	if (env.OLLAMA_BASE_URL) return 'ollama'
-	return null
-}
-
-/**
- * Resolve embedding model for the active provider.
- *
- * @param {'openai' | 'ollama'} provider
- * @returns {string}
- */
-export function resolveEmbeddingModel(provider, preferredModel = null) {
-	if (preferredModel) return preferredModel
-	if (env.EMBEDDING_MODEL) return env.EMBEDDING_MODEL
-	return provider === 'openai' ? OPENAI_DEFAULT_MODEL : OLLAMA_DEFAULT_MODEL
-}
+import { resolveEmbeddingProvider, resolveEmbeddingModel } from '$lib/utils/llmModels'
 
 /**
  * Get embedding for text from configured provider.
@@ -55,11 +12,14 @@ export async function getEmbedding(text, preferredProvider = null, preferredMode
 	const trimmed = (text || '').trim()
 	if (!trimmed) return null
 
-	const provider = resolveEmbeddingProvider(preferredProvider)
+	const provider = resolveEmbeddingProvider(preferredProvider, env)
 	if (!provider) return null
 
 	if (provider === 'openai') {
 		return openaiEmbed(trimmed, preferredModel)
+	}
+	if (provider === 'google') {
+		return googleEmbed(trimmed, preferredModel)
 	}
 	return ollamaEmbed(trimmed, preferredModel)
 }
@@ -108,6 +68,35 @@ async function ollamaEmbed(text, preferredModel = null) {
 
 	const data = await response.json()
 	const vector = data?.embedding
+	if (!Array.isArray(vector)) return null
+	return new Float32Array(vector)
+}
+
+async function googleEmbed(text, preferredModel = null) {
+	const configuredModel = resolveEmbeddingModel('google', preferredModel)
+	const model = configuredModel.startsWith('models/')
+		? configuredModel
+		: `models/${configuredModel}`
+	const response = await fetch(
+		`https://generativelanguage.googleapis.com/v1beta/${model}:embedContent?key=${env.GOOGLE_API_KEY}`,
+		{
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content: {
+					parts: [{ text }]
+				}
+			})
+		}
+	)
+
+	if (!response.ok) {
+		const body = await response.text()
+		throw new Error(`Google embedding failed: ${response.status} ${body}`)
+	}
+
+	const data = await response.json()
+	const vector = data?.embedding?.values
 	if (!Array.isArray(vector)) return null
 	return new Float32Array(vector)
 }

--- a/src/lib/utils/llmModels.js
+++ b/src/lib/utils/llmModels.js
@@ -15,6 +15,29 @@ const providerMeta = [
 	{ value: 'ollama', label: 'Ollama (Local)', envVar: 'OLLAMA_BASE_URL' }
 ]
 
+const embeddingProviderMeta = [
+	{ value: 'openai', label: 'OpenAI', envVar: 'OPENAI_API_KEY' },
+	{ value: 'google', label: 'Google (Gemini)', envVar: 'GOOGLE_API_KEY' },
+	{ value: 'ollama', label: 'Ollama (Local)', envVar: 'OLLAMA_BASE_URL' }
+]
+
+export const embeddingModels = {
+	openai: [
+		{ value: 'text-embedding-3-small', label: 'text-embedding-3-small (Recommended)' },
+		{ value: 'text-embedding-3-large', label: 'text-embedding-3-large' },
+		{ value: 'text-embedding-ada-002', label: 'text-embedding-ada-002 (Legacy)' }
+	],
+	google: [
+		{ value: 'gemini-embedding-001', label: 'gemini-embedding-001 (Recommended)' },
+		{ value: 'text-embedding-004', label: 'text-embedding-004 (Legacy)' }
+	],
+	ollama: [
+		{ value: 'nomic-embed-text', label: 'nomic-embed-text (Recommended)' },
+		{ value: 'mxbai-embed-large', label: 'mxbai-embed-large' },
+		{ value: 'all-minilm', label: 'all-minilm' }
+	]
+}
+
 export const providers = providerMeta.map((provider) => ({
 	value: provider.value,
 	label: provider.label
@@ -108,6 +131,88 @@ export function getProviderOptionsWithAvailability(availableProviders) {
 }
 
 /**
+ * Return embedding providers configured in environment variables.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @returns {string[]}
+ */
+export function getAvailableEmbeddingProviders(env) {
+	return embeddingProviderMeta
+		.filter((provider) => env[provider.envVar])
+		.map((provider) => provider.value)
+}
+
+/**
+ * Get embedding providers and annotate ones missing configuration.
+ *
+ * @param {string[]} availableProviders - List of embedding provider IDs with API keys/URLs
+ * @returns {Array<{value: string, label: string}>}
+ */
+export function getEmbeddingProviderOptionsWithAvailability(availableProviders) {
+	const available = new Set(availableProviders || [])
+	return embeddingProviderMeta.map((provider) => ({
+		value: provider.value,
+		label: available.has(provider.value) ? provider.label : `${provider.label} (Missing API key)`
+	}))
+}
+
+/**
+ * Get embedding models for a provider.
+ *
+ * @param {string} provider
+ * @returns {Array<{value: string, label: string}>}
+ */
+export function getEmbeddingModelsForProvider(provider) {
+	return embeddingModels[provider] || []
+}
+
+/**
+ * Resolve embedding provider using configured provider availability.
+ *
+ * Precedence:
+ * 1. Preferred provider (from runtime settings) if supported and configured
+ * 2. First available configured provider
+ *
+ * @param {string | null | undefined} preferredProvider
+ * @param {Record<string, string | undefined>} env
+ * @returns {'openai' | 'google' | 'ollama' | null}
+ */
+export function resolveEmbeddingProvider(preferredProvider, env) {
+	const availableProviders = getAvailableEmbeddingProviders(env)
+	const preferred = (preferredProvider || '').trim().toLowerCase()
+
+	if (preferred) {
+		return availableProviders.includes(preferred) ? preferred : null
+	}
+
+	return availableProviders[0] ?? null
+}
+
+/**
+ * Resolve embedding model for a provider.
+ *
+ * Model precedence:
+ * 1. Explicit preferred model (admin/settings)
+ * 2. Provider default model from curated list
+ * 3. Hardcoded safety fallback
+ *
+ * @param {'openai' | 'google' | 'ollama'} provider
+ * @param {string | null | undefined} preferredModel
+ * @returns {string}
+ */
+export function resolveEmbeddingModel(provider, preferredModel) {
+	if (preferredModel) return preferredModel
+	return (
+		getEmbeddingModelsForProvider(provider)?.[0]?.value ||
+		(provider === 'openai'
+			? 'text-embedding-3-small'
+			: provider === 'google'
+				? 'gemini-embedding-001'
+				: 'nomic-embed-text')
+	)
+}
+
+/**
  * Get text models for a provider, with Custom option appended
  * @param {string} provider
  * @returns {Array<{value: string, label: string}>}
@@ -126,4 +231,17 @@ export function getImageModelsForProvider(provider) {
 	const models = imageModels[provider] || []
 	if (models.length === 0) return []
 	return [...models, { value: 'custom', label: 'Custom...' }]
+}
+
+/**
+ * Get default models for a provider (first model in each list is recommended).
+ * Used by ai.js for LLM invocation defaults.
+ *
+ * @param {string} provider
+ * @returns {{ text: string | null, image: string | null }}
+ */
+export function getDefaultModelsForProvider(provider) {
+	const text = textModels[provider]?.[0]?.value || null
+	const image = imageModels[provider]?.[0]?.value || null
+	return { text, image }
 }

--- a/src/routes/api/embeddings/generate/+server.js
+++ b/src/routes/api/embeddings/generate/+server.js
@@ -1,10 +1,8 @@
 import { json } from '@sveltejs/kit'
 import { prisma } from '$lib/server/prisma'
 import { requireAdmin } from '$lib/server/authHelpers'
-import {
-	semanticEmbeddingJobsEnabled,
-	regenerateRecipeEmbedding
-} from '$lib/server/semanticEmbedding'
+import { semanticEmbeddingJobsEnabled } from '$lib/server/semanticHelpers'
+import { regenerateRecipeEmbedding } from '$lib/server/semanticEmbedding'
 
 export async function POST({ request, locals }) {
 	requireAdmin(locals)

--- a/src/routes/api/site/+server.js
+++ b/src/routes/api/site/+server.js
@@ -5,14 +5,20 @@ import { normalizeBoolean } from '$lib/utils/normalize'
 export async function POST({ request, locals }) {
 	requireAdmin(locals)
 	const siteData = await request.json()
-
-	const registrationAllowed = normalizeBoolean(siteData.registrationAllowed)
-	if (registrationAllowed === null) {
-		return jsonError(400, 'Invalid input data')
+	const hasRegistrationAllowed = Object.prototype.hasOwnProperty.call(
+		siteData,
+		'registrationAllowed'
+	)
+	const normalizedRegistrationAllowed = normalizeBoolean(siteData.registrationAllowed)
+	if (hasRegistrationAllowed && normalizedRegistrationAllowed === null) {
+		return jsonError(400, 'Invalid input data: registrationAllowed must be boolean.')
 	}
 
 	try {
 		const settings = await prisma.siteSettings.findFirst()
+		const registrationAllowed = hasRegistrationAllowed
+			? normalizedRegistrationAllowed
+			: settings.registrationAllowed
 		const updatedSettings = await prisma.siteSettings.update({
 			where: { id: settings.id },
 			data: {
@@ -22,6 +28,7 @@ export async function POST({ request, locals }) {
 					normalizeBoolean(siteData.oidcAutoProvision) ?? settings.oidcAutoProvision,
 				llmEnabled: normalizeBoolean(siteData.llmEnabled) ?? settings.llmEnabled,
 				llmProvider: siteData.llmProvider ?? settings.llmProvider,
+				llmImageProvider: siteData.llmImageProvider ?? settings.llmImageProvider,
 				llmTextModel: siteData.llmTextModel ?? settings.llmTextModel,
 				llmImageModel: siteData.llmImageModel ?? settings.llmImageModel,
 				semanticEnabled: normalizeBoolean(siteData.semanticEnabled) ?? settings.semanticEnabled,
@@ -32,6 +39,17 @@ export async function POST({ request, locals }) {
 		})
 		return jsonSuccess(updatedSettings)
 	} catch (err) {
+		console.error('Failed to update site settings', {
+			userId: locals?.user?.userId ?? null,
+			fields: Object.keys(siteData || {}),
+			llmProvider: siteData?.llmProvider ?? null,
+			llmImageProvider: siteData?.llmImageProvider ?? null,
+			semanticEmbeddingProvider: siteData?.semanticEmbeddingProvider ?? null,
+			hasLlmTextModel: !!siteData?.llmTextModel,
+			hasLlmImageModel: !!siteData?.llmImageModel,
+			hasSemanticEmbeddingModel: !!siteData?.semanticEmbeddingModel,
+			error: err?.message
+		})
 		return jsonError(500, `Failed to update site settings: ${err.message}`)
 	}
 }

--- a/src/routes/user/[id]/(private)/options/admin/site/+page.server.js
+++ b/src/routes/user/[id]/(private)/options/admin/site/+page.server.js
@@ -11,13 +11,13 @@ export const load = async ({ parent, locals }) => {
 		hasAnyApiKey: false,
 		availableProviders: [],
 		provider: null,
+		imageProvider: null,
 		textModel: null,
 		imageModel: null,
 		imageAllowed: false
 	}
 	const semantic = locals.site?.semantic ?? {
 		enabled: false,
-		enabledByEnv: false,
 		enabledBySite: false,
 		providerAvailable: false,
 		provider: null
@@ -34,19 +34,19 @@ export const load = async ({ parent, locals }) => {
 		hasAnyApiKey: ai.hasAnyApiKey,
 		availableProviders: ai.availableProviders,
 		provider: ai.provider,
+		imageProvider: ai.imageProvider,
 		textModel: ai.textModel,
 		imageModel: ai.imageModel,
 		imageAllowed: ai.imageAllowed,
 		// DB values for form binding
 		dbEnabled: dbSettings.llmEnabled ?? false,
 		dbProvider: dbSettings.llmProvider ?? null,
+		dbImageProvider: dbSettings.llmImageProvider ?? null,
 		dbTextModel: dbSettings.llmTextModel ?? null,
 		dbImageModel: dbSettings.llmImageModel ?? null,
 		dbSemanticEnabled: dbSettings.semanticEnabled ?? false,
 		dbSemanticEmbeddingProvider: dbSettings.semanticEmbeddingProvider ?? null,
 		dbSemanticEmbeddingModel: dbSettings.semanticEmbeddingModel ?? null,
-		semanticEnabledByEnv: semantic.enabledByEnv,
-		semanticProviderAvailable: semantic.providerAvailable,
 		semanticProvider: semantic.provider,
 		semanticAvailableProviders: semantic.availableProviders ?? [],
 		semanticSelectedProvider: semantic.selectedProvider ?? null,

--- a/src/routes/user/[id]/(private)/options/admin/site/+page.svelte
+++ b/src/routes/user/[id]/(private)/options/admin/site/+page.svelte
@@ -3,6 +3,8 @@
 	import { invalidateAll } from '$app/navigation'
 	import {
 		getProviderOptionsWithAvailability,
+		getEmbeddingProviderOptionsWithAvailability,
+		getEmbeddingModelsForProvider,
 		getTextModelsForProvider,
 		getImageModelsForProvider
 	} from '$lib/utils/llmModels.js'
@@ -52,8 +54,11 @@
 	let semanticEmbeddingModel = $state(
 		llmConfig.dbSemanticEmbeddingModel || llmConfig.semanticModel || ''
 	)
-	const initialProvider = llmConfig.dbProvider || llmConfig.availableProviders[0] || ''
-	let llmProvider = $state(initialProvider)
+	const initialTextProvider = llmConfig.dbProvider || llmConfig.availableProviders[0] || ''
+	const initialImageProvider =
+		llmConfig.dbImageProvider || llmConfig.imageProvider || initialTextProvider
+	let llmProvider = $state(initialTextProvider)
+	let llmImageProvider = $state(initialImageProvider)
 
 	// Check if current model is in the list or custom
 	function getModelSelection(currentModel, provider, isImage = false) {
@@ -66,8 +71,12 @@
 	}
 
 	// Compute initial selections based on DB values and initial provider
-	const initialTextSelection = getModelSelection(llmConfig.dbTextModel, initialProvider, false)
-	const initialImageSelection = getModelSelection(llmConfig.dbImageModel, initialProvider, true)
+	const initialTextSelection = getModelSelection(llmConfig.dbTextModel, initialTextProvider, false)
+	const initialImageSelection = getModelSelection(
+		llmConfig.dbImageModel,
+		initialImageProvider,
+		true
+	)
 
 	let textModelSelection = $state(initialTextSelection)
 	let imageModelSelection = $state(initialImageSelection)
@@ -77,18 +86,24 @@
 	)
 
 	let textModelList = $derived(getTextModelsForProvider(llmProvider))
-	let imageModelList = $derived(getImageModelsForProvider(llmProvider))
+	let imageModelList = $derived(getImageModelsForProvider(llmImageProvider))
 
 	// Track provider changes to reset model selections
-	let previousProvider = initialProvider
+	let previousProvider = initialTextProvider
+	let previousImageProvider = initialImageProvider
 	$effect(() => {
 		if (llmProvider !== previousProvider) {
 			previousProvider = llmProvider
 			const newTextModels = getTextModelsForProvider(llmProvider)
-			const newImageModels = getImageModelsForProvider(llmProvider)
 			textModelSelection = newTextModels[0]?.value || ''
-			imageModelSelection = newImageModels[0]?.value || ''
 			customTextModel = ''
+		}
+	})
+	$effect(() => {
+		if (llmImageProvider !== previousImageProvider) {
+			previousImageProvider = llmImageProvider
+			const newImageModels = getImageModelsForProvider(llmImageProvider)
+			imageModelSelection = newImageModels[0]?.value || ''
 			customImageModel = ''
 		}
 	})
@@ -96,17 +111,9 @@
 	let showCustomTextInput = $derived(textModelSelection === 'custom')
 	let showCustomImageInput = $derived(imageModelSelection === 'custom')
 	let supportsImages = $derived(imageModelList.length > 0)
-	const semanticProviderCatalog = [
-		{ value: 'openai', label: 'OpenAI', envVar: 'OPENAI_API_KEY' },
-		{ value: 'ollama', label: 'Ollama (Local)', envVar: 'OLLAMA_BASE_URL' }
-	]
-	let semanticProviderOptions = $derived.by(() => {
-		const available = new Set(llmConfig.semanticAvailableProviders || [])
-		return semanticProviderCatalog.map((provider) => ({
-			value: provider.value,
-			label: available.has(provider.value) ? provider.label : `${provider.label} (Missing API key)`
-		}))
-	})
+	let semanticProviderOptions = $derived(
+		getEmbeddingProviderOptionsWithAvailability(llmConfig.semanticAvailableProviders)
+	)
 	let effectiveSemanticProvider = $derived(
 		semanticEmbeddingProvider || llmConfig.semanticProvider || null
 	)
@@ -114,23 +121,7 @@
 		!!effectiveSemanticProvider &&
 			(llmConfig.semanticAvailableProviders || []).includes(effectiveSemanticProvider)
 	)
-	let semanticModelOptions = $derived.by(() => {
-		if (effectiveSemanticProvider === 'openai') {
-			return [
-				{ value: 'text-embedding-3-small', label: 'text-embedding-3-small (Recommended)' },
-				{ value: 'text-embedding-3-large', label: 'text-embedding-3-large' },
-				{ value: 'text-embedding-ada-002', label: 'text-embedding-ada-002 (Legacy)' }
-			]
-		}
-		if (effectiveSemanticProvider === 'ollama') {
-			return [
-				{ value: 'nomic-embed-text', label: 'nomic-embed-text (Recommended)' },
-				{ value: 'mxbai-embed-large', label: 'mxbai-embed-large' },
-				{ value: 'all-minilm', label: 'all-minilm' }
-			]
-		}
-		return []
-	})
+	let semanticModelOptions = $derived(getEmbeddingModelsForProvider(effectiveSemanticProvider))
 	$effect(() => {
 		if (!semanticEmbeddingModel && semanticModelOptions.length > 0) {
 			semanticEmbeddingModel = semanticModelOptions[0].value
@@ -138,9 +129,9 @@
 	})
 	let canGenerateEmbeddings = $derived(
 		semanticEnabled &&
-			llmConfig.semanticEnabledByEnv &&
 			semanticProviderConfigured &&
-			!!effectiveSemanticProvider
+			!!effectiveSemanticProvider &&
+			embeddingIndex.remaining > 0
 	)
 
 	// Get the actual model value to save
@@ -167,7 +158,9 @@
 		if (response.ok) {
 			settingsFeedback = 'Settings updated successfully!'
 		} else {
-			settingsFeedback = 'There was a problem updating your settings!'
+			const error = await response.json().catch(() => ({}))
+			settingsFeedback =
+				error.error || error.message || 'There was a problem updating your settings!'
 		}
 	}
 
@@ -181,6 +174,7 @@
 				llmEnabled,
 				semanticEnabled,
 				llmProvider,
+				llmImageProvider,
 				llmTextModel: effectiveTextModel || null,
 				llmImageModel: supportsImages ? effectiveImageModel || null : null,
 				semanticEmbeddingProvider: semanticEmbeddingProvider || null,
@@ -191,7 +185,8 @@
 			llmFeedback = 'LLM settings updated successfully!'
 			await invalidateAll()
 		} else {
-			llmFeedback = 'There was a problem updating LLM settings!'
+			const error = await response.json().catch(() => ({}))
+			llmFeedback = error.error || error.message || 'There was a problem updating LLM settings!'
 		}
 	}
 
@@ -333,127 +328,137 @@
 				Enable AI-assisted recipe parsing and image analysis
 			</Checkbox>
 
-			<Checkbox
-				name="semanticEnabled"
-				bind:checked={semanticEnabled}
-				legend="Enable Semantic Search"
-				size="sm"
-				color="primary"
-				disabled={!llmConfig.semanticEnabledByEnv || !llmConfig.semanticProviderAvailable}>
-				Enable embedding-based recipe search
-			</Checkbox>
-
-			{#if !llmConfig.semanticEnabledByEnv}
-				<InfoText>
-					Set <code>SEMANTIC_SEARCH_ENABLED=true</code> in your <code>.env</code> file to enable this
-					feature.
-				</InfoText>
-			{:else if !(llmConfig.semanticAvailableProviders || []).length}
-				<InfoText>
-					No embedding providers configured. Add <code>OPENAI_API_KEY</code> and/or
-					<code>OLLAMA_BASE_URL</code> in <code>.env</code>.
-				</InfoText>
-			{/if}
-
-			{#if semanticEnabled}
-				<div class="rounded-box border border-base-300 bg-base-200 p-4 space-y-2">
-					<p class="font-semibold">Semantic Embedding Index</p>
-					<InfoText>Generate embeddings for recipes missing vectors.</InfoText>
-					<InfoText>
-						Batches run from this page. If you navigate away, processing pauses after the current
-						batch and can be resumed later.
-					</InfoText>
-					{#if semanticEmbeddingProvider && !semanticProviderConfigured}
-						<InfoText>
-							Selected embedding provider is not configured in <code>.env</code>.
-						</InfoText>
-					{/if}
-					<p class="text-sm">
-						Indexed: {embeddingIndex.completed} / {embeddingIndex.total} ({embeddingIndex.remaining}
-						remaining)
-					</p>
-					<progress
-						class="progress progress-info w-full"
-						value={embeddingPercent}
-						max="100"
-						aria-label="Embedding generation progress"></progress>
-					<p class="text-xs text-base-content/70">{embeddingPercent}% complete</p>
-					<Button
-						type="button"
-						class="self-start w-auto"
-						onclick={generateEmbeddingBatch}
-						disabled={embeddingInProgress || !canGenerateEmbeddings}>
-						{embeddingInProgress ? 'Generating Embeddings...' : 'Generate Embeddings'}
-					</Button>
-					{#if embeddingBatchResult}
-						<p class="text-sm">
-							Processed: {embeddingBatchResult.processed}, Failed: {embeddingBatchResult.failed},
-							Remaining: {embeddingBatchResult.remaining}
-						</p>
-					{/if}
-					<FeedbackMessage message={embeddingFeedback} inline />
-				</div>
-			{/if}
-
 			{#if llmEnabled}
+				<h4>Text</h4>
+				<InfoText
+					>Used for recipe fallback parsing/translation/generation, ingredient cleanup, and
+					direction summarising.</InfoText>
 				<Dropdown
 					name="llmProvider"
 					options={availableProviderOptions}
 					bind:selected={llmProvider}
-					legend="Text/Image Provider" />
+					legend="Provider" />
 
 				<div class="flex flex-col gap-2">
 					<Dropdown
 						name="textModel"
 						options={textModelList}
 						bind:selected={textModelSelection}
-						legend="Text Model (for recipe parsing)" />
+						legend="Model" />
 					{#if showCustomTextInput}
 						<Input
 							type="text"
 							id="customTextModel"
-							label="Custom Text Model"
+							label="Custom Model"
 							placeholder="e.g. gpt-4o-2024-08-06"
 							bind:value={customTextModel} />
 					{/if}
 				</div>
-				{#if supportsImages}
-					<div class="flex flex-col gap-2">
+				<h4>Image</h4>
+				<InfoText>Used for recipe extraction from uploaded images.</InfoText>
+				<div class="flex flex-col gap-2">
+					<Dropdown
+						name="imageProvider"
+						options={availableProviderOptions}
+						bind:selected={llmImageProvider}
+						legend="Provider" />
+					{#if supportsImages}
 						<Dropdown
 							name="imageModel"
 							options={imageModelList}
 							bind:selected={imageModelSelection}
-							legend="Image Model (for image analysis)" />
+							legend="Model" />
 						{#if showCustomImageInput}
 							<Input
 								type="text"
 								id="customImageModel"
-								label="Custom Image Model"
+								label="Custom Model"
 								placeholder="e.g. claude-3-5-sonnet-20241022"
 								bind:value={customImageModel} />
 						{/if}
-					</div>
-				{:else}
-					<InfoText>
-						{llmProvider === 'ollama' ? 'Ollama' : 'This provider'} does not support image analysis.
-					</InfoText>
-				{/if}
+					{:else}
+						<InfoText>
+							{llmImageProvider === 'ollama' ? 'Ollama' : llmImageProvider || 'This provider'} does not
+							support image analysis.
+						</InfoText>
+					{/if}
+				</div>
 
-				<div class="mt-2 border-t border-base-300 pt-3 flex flex-col gap-2">
+				<h4>Semantic Search</h4>
+				<InfoText>Used for embedding-based relevance ranking in search results.</InfoText>
+				<div class="flex flex-col gap-2">
+					<Checkbox
+						name="semanticEnabled"
+						bind:checked={semanticEnabled}
+						legend="Enable Semantic Search"
+						size="sm"
+						color="primary"
+						disabled={!(llmConfig.semanticAvailableProviders || []).length}>
+						Enable embedding-based recipe search
+					</Checkbox>
+					{#if !(llmConfig.semanticAvailableProviders || []).length}
+						<InfoText>
+							No embedding providers configured. Add <code>OPENAI_API_KEY</code>,
+							<code>GOOGLE_API_KEY</code> and/or <code>OLLAMA_BASE_URL</code> in
+							<code>.env</code>.
+						</InfoText>
+					{/if}
 					<Dropdown
 						name="semanticEmbeddingProvider"
 						options={semanticProviderOptions}
 						bind:selected={semanticEmbeddingProvider}
-						legend="Embedding Provider" />
+						legend="Provider"
+						disabled={!semanticEnabled} />
 					{#if semanticModelOptions.length > 0}
 						<Dropdown
 							name="semanticEmbeddingModel"
 							options={semanticModelOptions}
 							bind:selected={semanticEmbeddingModel}
-							legend="Embedding Model"
-							disabled={!semanticProviderConfigured} />
+							legend="Model"
+							disabled={!semanticEnabled || !semanticProviderConfigured} />
 					{:else}
 						<InfoText>Select an embedding provider to choose a model.</InfoText>
+					{/if}
+					{#if semanticEmbeddingProvider && !semanticProviderConfigured}
+						<InfoText>
+							{#if semanticEmbeddingProvider === 'ollama'}
+								Please add <code>OLLAMA_BASE_URL</code> to <code>.env</code>.
+							{:else if semanticEmbeddingProvider === 'google'}
+								Please add <code>GOOGLE_API_KEY</code> to <code>.env</code>.
+							{:else if semanticEmbeddingProvider === 'openai'}
+								Please add <code>OPENAI_API_KEY</code> to <code>.env</code>.
+							{:else}
+								Selected provider is missing configuration in <code>.env</code>.
+							{/if}
+						</InfoText>
+					{/if}
+					{#if semanticEnabled}
+						<div class="rounded-box border border-base-300 bg-base-200 p-4 mt-2 space-y-2">
+							<p class="text-sm">
+								Indexed: {embeddingIndex.completed} / {embeddingIndex.total} ({embeddingIndex.remaining}
+								remaining)
+							</p>
+							<progress
+								class="progress progress-info w-full"
+								value={embeddingPercent}
+								max="100"
+								aria-label="Embedding generation progress"></progress>
+							<p class="text-xs text-base-content/70">{embeddingPercent}% complete</p>
+							<Button
+								type="button"
+								class="self-start w-auto"
+								onclick={generateEmbeddingBatch}
+								disabled={embeddingInProgress || !canGenerateEmbeddings}>
+								{embeddingInProgress ? 'Generating Embeddings...' : 'Generate Embeddings'}
+							</Button>
+							{#if embeddingBatchResult}
+								<p class="text-sm">
+									Processed: {embeddingBatchResult.processed}, Failed: {embeddingBatchResult.failed},
+									Remaining: {embeddingBatchResult.remaining}
+								</p>
+							{/if}
+							<FeedbackMessage message={embeddingFeedback} inline />
+						</div>
 					{/if}
 				</div>
 			{/if}
@@ -468,7 +473,7 @@
 
 <div class="w-full md:w-3/4 lg:w-2/3 space-y-2 mb-3">
 	<h3>Password Requirements</h3>
-	<div class="rounded-box border border-base-300 bg-base-200 p-4 space-y-1">
+	<div class="rounded-box border border-base-300 bg-base-200 p-4 mt-4 space-y-1">
 		<p>
 			<strong>Summary:</strong>
 			{passwordRequirementsDescription || 'Using default password requirements.'}


### PR DESCRIPTION
- Refactored semantic configuration to be settings-driven (admin/DB) and removed mixed env-model fallback behavior.
- Consolidated embedding provider/model resolution into `src/lib/utils/llmModels.js` to reduce duplication.
- Added Google/Gemini embeddings support (provider option, model options, and runtime embedding path).
- Hardened `/api/site` updates:
  - accepts partial payloads (LLM-only updates without requiring `registrationAllowed`)
  - adds safe server-side error context logging for debugging.
- Improved admin settings feedback:
  - display API error messages instead of generic failure text.
- Added provider-specific missing-config guidance in admin UI:
  - OpenAI -> `OPENAI_API_KEY`
  - Google -> `GOOGLE_API_KEY`
  - Ollama -> `OLLAMA_BASE_URL`
- Tightened semantic search trigger behavior in `RecipeFeed.svelte`:
  - semantic request only for 4+ characters
  - 500ms debounce.
- Split text/image provider configuration:
  - separate image provider setting wired through DB/API/hooks/UI
  - backward-compatible fallback to text provider.
- Reworked admin LLM settings layout into clear sections:
  - Text
  - Image
  - Semantic Search
  with simplified dropdown labels (`Provider`, `Model`) and semantic controls ordered as:
  enabled -> provider/model -> index.
- Added click-outside close behavior for `<details>` dropdowns in `DropdownMenu.svelte` (fixes RecipeFilter dropdowns staying open).
- Updated docs/manual with:
  - semantic cost ballparks
  - Ollama embedding model suggestions
  - clearer provider/model setup guidance.