### PR TITLE
Nutrition parsing/display, mobile layout refinement

### DIFF
--- a/src/lib/components/recipe/RecipeViewDesc.svelte
+++ b/src/lib/components/recipe/RecipeViewDesc.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { getSanitizedHTML } from '$lib/utils/render'
+	import CollapseSection from '$lib/components/ui/CollapseSection.svelte'
 	
 	/** @type {{recipe: any}} */
 	let { recipe } = $props();
@@ -25,10 +26,11 @@
 </script>
 
 {#if sanitisedDescription.length > 0}
-	<div class="prose max-w-none">
-		<h3>Description</h3>
-		{#each sanitisedDescription as parsedDescription}
-			<p>{@html parsedDescription}</p>
-		{/each}
-	</div>
+	<CollapseSection title="Description" className="mt-2">
+		<div class="prose max-w-none">
+			{#each sanitisedDescription as parsedDescription}
+				<p>{@html parsedDescription}</p>
+			{/each}
+		</div>
+	</CollapseSection>
 {/if}

--- a/src/lib/components/recipe/RecipeViewNotes.svelte
+++ b/src/lib/components/recipe/RecipeViewNotes.svelte
@@ -1,5 +1,6 @@
 <script>
 	import RecipeViewLogs from './RecipeViewLogs.svelte'
+	import CollapseSection from '$lib/components/ui/CollapseSection.svelte'
 
 	/** @type {{notesLines?: any, sanitizedNotes?: any, logs?: any}} */
 	let { notesLines = [], sanitizedNotes = [], logs = [] } = $props()
@@ -8,13 +9,14 @@
 </script>
 
 {#if notesLines.length > 0 || safeLogs.some((log) => log.note)}
-	<div class="prose max-w-none mt-6">
-		{#if notesLines.length > 0 || safeLogs.length > 0}
-			<h3>Notes</h3>
-			{#each sanitizedNotes as parsedNote}
-				<p>{@html parsedNote}</p>
-			{/each}
-		{/if}
-		<RecipeViewLogs logs={safeLogs} />
-	</div>
+	<CollapseSection title="Notes" className="mt-6">
+		<div class="prose max-w-none">
+			{#if notesLines.length > 0 || safeLogs.length > 0}
+				{#each sanitizedNotes as parsedNote}
+					<p>{@html parsedNote}</p>
+				{/each}
+			{/if}
+			<RecipeViewLogs logs={safeLogs} />
+		</div>
+	</CollapseSection>
 {/if}

--- a/src/lib/components/ui/CollapseSection.svelte
+++ b/src/lib/components/ui/CollapseSection.svelte
@@ -1,0 +1,12 @@
+<script>
+	/** @type {{ title?: string, open?: boolean, className?: string, children?: import('svelte').Snippet }} */
+	let { title = '', open = false, className = '', children = undefined } = $props()
+</script>
+
+<div class={`collapse collapse-arrow bg-base-100 border border-base-300 ${className}`.trim()}>
+	<input type="checkbox" checked={open} />
+	<div class="collapse-title font-semibold">{title}</div>
+	<div class="collapse-content text-sm">
+		{@render children?.()}
+	</div>
+</div>

--- a/src/routes/recipe/(public)/[recipeId]/view/+page.svelte
+++ b/src/routes/recipe/(public)/[recipeId]/view/+page.svelte
@@ -399,15 +399,17 @@
 					onScaleChange={handleScaleChange}
 					onSelectedSystemChange={handleSelectedSystemChange}
 				/>
-				<RecipeViewNutrition
-					nutritionalInfo={recipe.nutritional_info}
-					{scale}
-					language={viewUser.language}
-					recipeUid={recipe.uid}
-					showCleanupAction={!viewOnly && aiEnabled}
-					cleanupInProgress={cleaningNutrition}
-					onCleanup={viewOnly ? null : handleCleanNutritionInView}
-				/>
+				<div class="hidden md:block">
+					<RecipeViewNutrition
+						nutritionalInfo={recipe.nutritional_info}
+						{scale}
+						language={viewUser.language}
+						recipeUid={recipe.uid}
+						showCleanupAction={!viewOnly && aiEnabled}
+						cleanupInProgress={cleaningNutrition}
+						onCleanup={viewOnly ? null : handleCleanNutritionInView}
+					/>
+				</div>
 			{:else}
 				<div class="flex justify-center items-center p-8">
 					<span class="loading loading-spinner loading-md text-primary"></span>
@@ -428,6 +430,18 @@
 			<RecipeViewDirections {directionLines} {sanitizedDirections} {loadingIngredients} />
 			<RecipeViewNotes {notesLines} {sanitizedNotes} logs={viewOnly ? [] : logs} />
 		</div>
+	</div>
+
+	<div class="md:hidden">
+		<RecipeViewNutrition
+			nutritionalInfo={recipe.nutritional_info}
+			{scale}
+			language={viewUser.language}
+			recipeUid={recipe.uid}
+			showCleanupAction={!viewOnly && aiEnabled}
+			cleanupInProgress={cleaningNutrition}
+			onCleanup={viewOnly ? null : handleCleanNutritionInView}
+		/>
 	</div>
 {/if}
 


### PR DESCRIPTION
# Release Notes

- Added:
  - Nutrition is now shown on recipe pages in a structured table with per-serving/per-recipe status.
  - Added a reusable `CollapseSection` UI component for collapsible content blocks.
- Changed:
  - On mobile, nutrition now renders at the bottom of the recipe view to avoid interrupting ingredient/directions flow.
  - Description and Notes are now displayed in collapsible sections on recipe view.
- Related issues:
  - #362