### PR TITLE
#378 non-root docker image migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,30 @@
 # Use the official Node.js runtime as the base image
 FROM node:20
 
-# Install build dependencies for native modules (better-sqlite3) and cron
+# Install build dependencies for native modules (better-sqlite3), cron and gosu
 RUN apt-get update && apt-get install -y \
     python3 \
     make \
     g++ \
     cron \
+    gosu \
     && rm -rf /var/lib/apt/lists/*
-
-# Install pnpm globally
-RUN npm install -g pnpm
 
 # Set the working directory
 WORKDIR /app
+
+# Set global bin directory for pnpm
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+
+# Install pnpm globally
+RUN npm install -g pnpm
 
 # Copy package.json and pnpm-lock.yaml
 COPY package.json pnpm-lock.yaml ./
 
 # Install dependencies
 RUN pnpm install
-
-# Set global bin directory for pnpm
-ENV PNPM_HOME=/root/.pnpm
-ENV PATH=$PNPM_HOME:$PATH
 
 # Set git version
 ARG GIT_VERSION=unknown
@@ -38,14 +39,11 @@ ENV BODY_SIZE_LIMIT=5242880
 # Copy the current directory contents into the container
 COPY . .
 
+# Ensure runtime folders exist
+RUN mkdir -p /app/prisma/db /app/uploads/images /app/uploads/imports /pnpm
+
 # Make scripts executable
 RUN chmod +x /app/scripts/docker/entrypoint.sh /app/scripts/backup/backup-db.sh
-
-ENTRYPOINT ["/app/scripts/docker/entrypoint.sh"]
-
-# Create DB folder
-RUN mkdir -p /app/prisma/db
-RUN mkdir -p /app/uploads/images /app/uploads/imports
 
 # Approve build scripts for better-sqlite3 and prisma
 RUN pnpm config set enable-pre-post-scripts true || true
@@ -54,6 +52,13 @@ RUN pnpm config set enable-pre-post-scripts true || true
 # Generate the service worker
 # Build SvelteKit app
 RUN pnpm build
+
+# Set ownership of runtime-writable paths and executables
+# (node_modules/build artifacts only need world-read, not node ownership)
+RUN chown -R node:node /app/prisma/db /app/uploads /app/scripts /app/build /pnpm \
+    && chmod -R a+rX /app
+
+ENTRYPOINT ["/app/scripts/docker/entrypoint.sh"]
 
 # Expose the application's port
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Docker installations include automatic backups to protect your recipe data:
 - **Retention management**: Configure how many scheduled backups to keep with `BACKUP_RETENTION_COUNT` in `.env` (default: 6).
 - **Accessible backups**: All backups are stored in your mounted `./db` folder alongside your active database:
   - `scheduled-backup-YYYYMMDD-HHMMSS.sqlite` - Regular scheduled backups (auto-cleaned)
-  - `auto-backup-YYYYMMDD-HHMMSS.sqlite` - Pre-migration backups (preserved)
+  - `migration-YYYYMMDD-HHMMSS.sqlite` - Pre-migration backups (preserved)
 
 After changing backup settings, restart the container: `docker-compose restart`
 
@@ -166,12 +166,60 @@ Docker set up is dead simple. Single container, portable SQLite database.
 4. Use `:latest` tags for bleedin' edge, `:stable` for stable release.
 5. Run `docker-compose up -d`
 6. On first run, you'll be prompted to enter Admin user details.
+7. Optional: set `PUID` and `PGID` (in your shell or `.env`) if you want container file ownership to match a specific host user. Defaults are `1000:1000`.
 
 #### Upgrade
 
 1. Grab the latest image: `docker pull jt196/vanilla-cookbook`
 2. Check the *.env.template* and *docker-compose.yml.template* files haven't been modified. Add any additional fields. The *.env* is the most likely to change.
-3. From the project directory, run `docker-compose up -d` or `docker compose up -d` depending on how you have it installed on your system.
+3. If upgrading from an older image that wrote files as root, run the migration guide below before restarting.
+4. From the project directory, run `docker-compose up -d` or `docker compose up -d` depending on how you have it installed on your system.
+
+#### Docker Non-Root Migration Guide
+
+Vanilla Cookbook now runs the app process as a non-root user in the container. Existing installs may need a one-time ownership fix on mounted volumes.
+
+1. Stop the container:
+   - `docker compose down`
+2. Back up your DB folder:
+   - `cp -r ./db ./db-backup-$(date +%Y%m%d-%H%M%S)`
+3. Start the updated container:
+   - `docker compose up -d`
+4. Validate:
+   - `docker compose logs -f app` and confirm no writable-permission errors
+   - create/edit a recipe
+   - upload an image
+5. Only if permission errors remain, run a manual ownership fix:
+   - `PUID=${PUID:-1000} PGID=${PGID:-1000} sudo chown -R "${PUID}:${PGID}" ./db ./uploads`
+   - then restart: `docker compose up -d`
+6. Optional: set `PUID`/`PGID` if you want a specific host-user mapping:
+   - `export PUID=$(id -u)`
+   - `export PGID=$(id -g)`
+
+#### Local Docker Testing (No Docker Hub Push Required)
+
+Use this before testing on a remote host.
+
+1. In `docker-compose.yml`, switch from `image:` to:
+
+   ```yaml
+   build:
+     context: .
+   ```
+
+2. Build locally:
+   - `docker compose build --no-cache`
+3. Run:
+   - `docker compose up -d`
+4. Optional user-mapping test:
+   - `PUID=$(id -u) PGID=$(id -g) docker compose up -d`
+5. Verify the runtime user and permissions:
+   - `docker compose exec app id`
+   - `docker compose exec app sh -lc 'touch /app/uploads/images/perm-test && rm /app/uploads/images/perm-test'`
+6. Validate upgrade path locally:
+   - temporarily create root-owned files in `./db` or `./uploads`
+   - start the container and check logs for permission warnings
+   - run the migration guide `chown` step and confirm the warnings are gone
 
 #### Reverse Proxy Configuration
 

--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -7,5 +7,9 @@ services:
     volumes:
       - ./db:/app/prisma/db
       - ./uploads:/app/uploads
+    environment:
+      # Optional: override to match your host user/group. Defaults to 1000:1000.
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
     env_file:
       - .env

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -1,57 +1,116 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# Check if the subdirectories exist and create them if not
-[ -d "/app/uploads/images" ] || mkdir -p /app/uploads/images
-[ -d "/app/uploads/imports" ] || mkdir -p /app/uploads/imports
+APP_USER="${APP_USER:-node}"
+APP_GROUP="${APP_GROUP:-node}"
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+CRON_SCHEDULE="${BACKUP_CRON_SCHEDULE:-0 3 * * 0}"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Permission checks - log warnings if folders/files aren't writable
-# ─────────────────────────────────────────────────────────────────────────────
-echo "🔍 Checking folder permissions..."
-
-check_writable() {
-    local path="$1"
-    local label="$2"
-    if [ -e "$path" ]; then
-        if [ -w "$path" ]; then
-            echo "  ✅ $label: writable"
-        else
-            echo "  ❌ $label: NOT WRITABLE - recipes may fail to save!"
-            echo "     Path: $path"
-            echo "     Fix: Check volume mount permissions (chmod/chown)"
-        fi
-    else
-        echo "  ⚠️  $label: does not exist yet (will be created)"
-    fi
+run_as_app() {
+  if [ "$(id -u)" -eq 0 ]; then
+    gosu "$APP_USER:$APP_GROUP" "$@"
+  else
+    "$@"
+  fi
 }
 
+ensure_directories() {
+  mkdir -p /app/prisma/db /app/uploads/images /app/uploads/imports
+}
+
+sync_user_ids() {
+  if [ "$(id -u)" -ne 0 ]; then
+    return
+  fi
+
+  resolved_group="$APP_GROUP"
+  resolved_user="$APP_USER"
+
+  existing_group_for_gid="$(getent group "$PGID" | cut -d: -f1 || true)"
+  if [ -n "$existing_group_for_gid" ]; then
+    resolved_group="$existing_group_for_gid"
+  else
+    current_gid="$(getent group "$APP_GROUP" | cut -d: -f3)"
+    if [ "$current_gid" != "$PGID" ]; then
+      groupmod -o -g "$PGID" "$APP_GROUP"
+    fi
+  fi
+
+  existing_user_for_uid="$(getent passwd "$PUID" | cut -d: -f1 || true)"
+  if [ -n "$existing_user_for_uid" ]; then
+    resolved_user="$existing_user_for_uid"
+  else
+    current_uid="$(id -u "$APP_USER")"
+    if [ "$current_uid" != "$PUID" ]; then
+      usermod -o -u "$PUID" "$APP_USER"
+    fi
+  fi
+
+  usermod -g "$resolved_group" "$resolved_user"
+  APP_USER="$resolved_user"
+  APP_GROUP="$resolved_group"
+
+  chown -R "$PUID:$PGID" /app/prisma/db /app/uploads
+}
+
+setup_backups() {
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "⚠️  Running without root; scheduled backups disabled (cron requires root setup)."
+    return
+  fi
+
+  echo "$CRON_SCHEDULE /app/scripts/backup/backup-db.sh >> /tmp/cron.log 2>&1" | crontab -u "$APP_USER" -
+  service cron start
+  echo "✅ Cron started for scheduled database backups (schedule: $CRON_SCHEDULE)"
+}
+
+check_writable() {
+  local path="$1"
+  local label="$2"
+
+  if [ -e "$path" ]; then
+    if run_as_app test -w "$path"; then
+      echo "  ✅ $label: writable"
+    else
+      echo "  ❌ $label: NOT WRITABLE - recipes may fail to save!"
+      echo "     Path: $path"
+      echo "     Fix: set PUID/PGID or run chown on mounted volumes"
+    fi
+  else
+    echo "  ⚠️  $label: does not exist yet (will be created)"
+  fi
+}
+
+create_migration_backup_if_needed() {
+  DB_PATH="/app/prisma/db/dev.sqlite"
+  if [ ! -f "$DB_PATH" ]; then
+    return
+  fi
+
+  if run_as_app pnpm prisma migrate status 2>&1 | grep -q "following migration.*not yet been applied"; then
+    BACKUP_PATH="/app/prisma/db/migration-$(date +%Y%m%d-%H%M%S).sqlite"
+    echo "⚠️  Pending migrations detected. Creating automatic backup: $BACKUP_PATH"
+    run_as_app cp "$DB_PATH" "$BACKUP_PATH"
+    echo "✅ Backup created successfully"
+  fi
+}
+
+ensure_directories
+sync_user_ids
+setup_backups
+
+echo "🔍 Checking folder permissions..."
 check_writable "/app/prisma/db" "Database folder"
 check_writable "/app/prisma/db/dev.sqlite" "Database file"
 check_writable "/app/uploads" "Uploads folder"
 check_writable "/app/uploads/images" "Images folder"
-
 echo ""
 
-# Set up cron schedule from env var (default: Sundays at 3am)
-CRON_SCHEDULE="${BACKUP_CRON_SCHEDULE:-0 3 * * 0}"
-echo "$CRON_SCHEDULE /app/scripts/backup/backup-db.sh >> /var/log/cron.log 2>&1" | crontab -
+create_migration_backup_if_needed
 
-# Start cron for scheduled backups
-service cron start
-echo "✅ Cron started for scheduled database backups (schedule: $CRON_SCHEDULE)"
-
-# Auto-backup database before migrations if there are pending changes
-DB_PATH="/app/prisma/db/dev.sqlite"
-if [ -f "$DB_PATH" ]; then
-    # Check if there are pending migrations
-    if pnpm prisma migrate status 2>&1 | grep -q "following migration.*not yet been applied"; then
-        BACKUP_PATH="/app/prisma/db/migration-$(date +%Y%m%d-%H%M%S).sqlite"
-        echo "⚠️  Pending migrations detected. Creating automatic backup: $BACKUP_PATH"
-        cp "$DB_PATH" "$BACKUP_PATH"
-        echo "✅ Backup created successfully"
-    fi
+if [ "$(id -u)" -eq 0 ]; then
+  exec gosu "$APP_USER:$APP_GROUP" pnpm serve
+else
+  exec pnpm serve
 fi
-
-# Run the production build and start the server
-pnpm serve


### PR DESCRIPTION
- Changed: Docker container now runs as a non-root user (`node`, UID 1000) for improved security (#378)                                                                                                                                         
- Changed: Pre-migration database backups are now named `migration-YYYYMMDD-HHMMSS.sqlite` (previously `auto-backup-...`)
- Added: Optional `PUID`/`PGID` env vars to match container file ownership to your host user (useful for NAS setups)                                                                                                                                                                                                                                                                                                                                                                         - Breaking changes: Mounted volume files (`./db`, `./uploads`) will now be owned by UID 1000. Existing installs with root-owned files may need a one-time permission fix (see migration steps below).
- Related issues: #378

---

## Migrating from a previous install

1. Stop the container: `docker compose down`
2. Back up your data: `cp -r ./db ./db-backup-$(date +%Y%m%d)`
3. Pull the new image and start: `docker compose up -d`
4. Check logs for permission errors: `docker compose logs -f app`
5. If you see permission errors on `./db` or `./uploads`, run: `sudo chown -R 1000:1000 ./db ./uploads` then `docker compose up -d`

**NAS users (Synology, Unraid, etc.):** Add `PUID` and `PGID` to your `.env` to match your host user e.g.:
`PUID=1024` (check your UID with `id -u` on the host)