### PR TITLE
embeddings bug fix closes #388

### DIFF
--- a/src/routes/api/embeddings/generate/+server.js
+++ b/src/routes/api/embeddings/generate/+server.js
@@ -3,6 +3,7 @@ import { prisma } from '$lib/server/prisma'
 import { requireAdmin } from '$lib/server/authHelpers'
 import { semanticEmbeddingJobsEnabled } from '$lib/server/semanticHelpers'
 import { regenerateRecipeEmbedding } from '$lib/server/semanticEmbedding'
+import { resolveEmbeddingModel } from '$lib/utils/llmModels'
 
 export async function POST({ request, locals }) {
 	requireAdmin(locals)
@@ -45,13 +46,16 @@ export async function POST({ request, locals }) {
 	const body = await request.json().catch(() => ({}))
 	const requestedBatchSize = Number(body?.batchSize || 10)
 	const batchSize = Math.min(Math.max(requestedBatchSize, 1), 100)
-	console.info(`[semantic] embedding batch start (batchSize=${batchSize})`)
+	const force = !!body?.force
+	console.info(`[semantic] embedding batch start (batchSize=${batchSize}, force=${force})`)
+
+	const resolvedModel = resolveEmbeddingModel(preferredEmbeddingProvider, preferredEmbeddingModel)
+	const whereClause = force
+		? { in_trash: false, OR: [{ embedding: null }, { embeddingModel: { not: resolvedModel } }] }
+		: { embedding: null, in_trash: false }
 
 	const recipes = await prisma.recipe.findMany({
-		where: {
-			embedding: null,
-			in_trash: false
-		},
+		where: whereClause,
 		select: { uid: true },
 		take: batchSize,
 		orderBy: { created: 'desc' }
@@ -87,10 +91,9 @@ export async function POST({ request, locals }) {
 	}
 
 	const remaining = await prisma.recipe.count({
-		where: {
-			embedding: null,
-			in_trash: false
-		}
+		where: force
+			? { in_trash: false, OR: [{ embedding: null }, { embeddingModel: { not: resolvedModel } }] }
+			: { embedding: null, in_trash: false }
 	})
 
 	console.info(
@@ -108,11 +111,22 @@ export async function POST({ request, locals }) {
 export async function GET({ locals }) {
 	requireAdmin(locals)
 
-	const [remaining, total] = await Promise.all([
+	const preferredEmbeddingProvider = locals.site?.semantic?.provider || null
+	const preferredEmbeddingModel = locals.site?.semantic?.model || null
+	const resolvedModel = resolveEmbeddingModel(preferredEmbeddingProvider, preferredEmbeddingModel)
+
+	const [remaining, mismatched, total] = await Promise.all([
 		prisma.recipe.count({
 			where: {
 				embedding: null,
 				in_trash: false
+			}
+		}),
+		prisma.recipe.count({
+			where: {
+				in_trash: false,
+				embedding: { not: null },
+				embeddingModel: { not: resolvedModel }
 			}
 		}),
 		prisma.recipe.count({
@@ -125,6 +139,7 @@ export async function GET({ locals }) {
 	return json({
 		total,
 		remaining,
-		completed: Math.max(total - remaining, 0)
+		mismatched,
+		completed: Math.max(total - remaining - mismatched, 0)
 	})
 }

--- a/src/routes/api/recipe/search/+server.js
+++ b/src/routes/api/recipe/search/+server.js
@@ -89,6 +89,7 @@ export async function GET({ url, locals }) {
 		for (const candidate of candidates) {
 			if (!candidate.embedding) continue
 			const embedding = deserializeEmbedding(candidate.embedding)
+			if (embedding.length !== queryEmbedding.length) continue
 			const score = cosineSimilarity(queryEmbedding, embedding)
 			if (score >= threshold) {
 				results.push({ uid: candidate.uid, score })

--- a/src/routes/user/[id]/(private)/options/admin/site/+page.server.js
+++ b/src/routes/user/[id]/(private)/options/admin/site/+page.server.js
@@ -1,5 +1,6 @@
 import { getBackupInfo } from '$lib/server/backups'
 import { prisma } from '$lib/server/prisma'
+import { resolveEmbeddingModel } from '$lib/utils/llmModels'
 
 export const load = async ({ parent, locals }) => {
 	// Get parent data (settings, user)
@@ -60,13 +61,22 @@ export const load = async ({ parent, locals }) => {
 		semanticModel: semantic.model ?? null
 	}
 
+	const resolvedModel = resolveEmbeddingModel(semantic.provider, semantic.model)
+
 	try {
-		const [backupInfo, embeddingRemaining, embeddingTotal] = await Promise.all([
+		const [backupInfo, embeddingRemaining, embeddingMismatched, embeddingTotal] = await Promise.all([
 			getBackupInfo(),
 			prisma.recipe.count({
 				where: {
 					embedding: null,
 					in_trash: false
+				}
+			}),
+			prisma.recipe.count({
+				where: {
+					in_trash: false,
+					embedding: { not: null },
+					embeddingModel: { not: resolvedModel }
 				}
 			}),
 			prisma.recipe.count({
@@ -78,7 +88,8 @@ export const load = async ({ parent, locals }) => {
 		const embeddingIndex = {
 			total: embeddingTotal,
 			remaining: embeddingRemaining,
-			completed: Math.max(embeddingTotal - embeddingRemaining, 0)
+			mismatched: embeddingMismatched,
+			completed: Math.max(embeddingTotal - embeddingRemaining - embeddingMismatched, 0)
 		}
 		return {
 			...parentData,
@@ -93,7 +104,7 @@ export const load = async ({ parent, locals }) => {
 			...parentData,
 			backupInfo: null,
 			backupError: `Failed to load backup information: ${error.message}`,
-			embeddingIndex: { total: 0, remaining: 0, completed: 0 },
+			embeddingIndex: { total: 0, remaining: 0, mismatched: 0, completed: 0 },
 			llmConfig,
 			oauth
 		}

--- a/src/routes/user/[id]/(private)/options/admin/site/+page.svelte
+++ b/src/routes/user/[id]/(private)/options/admin/site/+page.svelte
@@ -40,7 +40,9 @@
 	let embeddingInProgress = $state(false)
 	let embeddingFeedback = $state('')
 	let embeddingBatchResult = $state(null)
-	let embeddingIndex = $state(data.embeddingIndex || { total: 0, remaining: 0, completed: 0 })
+	let embeddingIndex = $state(
+		data.embeddingIndex || { total: 0, remaining: 0, mismatched: 0, completed: 0 }
+	)
 	let embeddingPercent = $derived(
 		embeddingIndex.total > 0
 			? Math.round((Math.max(embeddingIndex.completed, 0) / embeddingIndex.total) * 100)
@@ -162,6 +164,12 @@
 			!!effectiveSemanticProvider &&
 			embeddingIndex.remaining > 0
 	)
+	let canRegenerateMismatched = $derived(
+		semanticEnabled &&
+			semanticProviderConfigured &&
+			!!effectiveSemanticProvider &&
+			(embeddingIndex.mismatched || 0) > 0
+	)
 
 	// Get the actual model value to save
 	let effectiveTextModel = $derived(
@@ -249,7 +257,7 @@
 		}
 	}
 
-	async function generateEmbeddingBatch() {
+	async function generateEmbeddingBatch(force = false) {
 		embeddingInProgress = true
 		embeddingFeedback = ''
 		embeddingBatchResult = null
@@ -261,7 +269,7 @@
 				const response = await fetch('/api/embeddings/generate', {
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ batchSize: 25 })
+					body: JSON.stringify({ batchSize: 25, force })
 				})
 				const data = await response.json().catch(() => ({}))
 				if (!response.ok) {
@@ -274,8 +282,14 @@
 				embeddingBatchResult = data
 				embeddingIndex = {
 					total: embeddingIndex.total,
-					remaining: data.remaining ?? embeddingIndex.remaining,
-					completed: Math.max((embeddingIndex.total || 0) - (data.remaining || 0), 0)
+					remaining: force ? embeddingIndex.remaining : (data.remaining ?? embeddingIndex.remaining),
+					mismatched: force ? (data.remaining ?? embeddingIndex.mismatched) : embeddingIndex.mismatched,
+					completed: Math.max(
+						(embeddingIndex.total || 0) -
+							(force ? embeddingIndex.remaining : (data.remaining || 0)) -
+							(force ? (data.remaining || 0) : embeddingIndex.mismatched),
+						0
+					)
 				}
 
 				if (data.remaining === 0) break
@@ -286,7 +300,7 @@
 				if ((data.processed || 0) === 0) break
 			}
 
-			embeddingFeedback = `Embedding run complete: ${processedTotal} processed, ${failedTotal} failed, ${embeddingIndex.remaining} remaining.`
+			embeddingFeedback = `Embedding run complete: ${processedTotal} processed, ${failedTotal} failed.`
 		} catch (error) {
 			embeddingFeedback = `Error generating embeddings: ${error.message}`
 		} finally {
@@ -298,7 +312,7 @@
 	$effect(() => {
 		backupInfo = data.backupInfo
 		backupError = data.backupError || ''
-		embeddingIndex = data.embeddingIndex || { total: 0, remaining: 0, completed: 0 }
+		embeddingIndex = data.embeddingIndex || { total: 0, remaining: 0, mismatched: 0, completed: 0 }
 	})
 
 	async function testConnection(provider, model, type) {
@@ -660,14 +674,31 @@
 								aria-label="Embedding generation progress"
 							></progress>
 							<p class="text-xs text-base-content/70">{embeddingPercent}% complete</p>
-							<Button
-								type="button"
-								class="self-start w-auto"
-								onclick={generateEmbeddingBatch}
-								disabled={embeddingInProgress || !canGenerateEmbeddings}
-							>
-								{embeddingInProgress ? 'Generating Embeddings...' : 'Generate Embeddings'}
-							</Button>
+							{#if (embeddingIndex.mismatched || 0) > 0}
+								<p class="text-sm text-warning">
+									{embeddingIndex.mismatched} recipe{embeddingIndex.mismatched === 1 ? '' : 's'} indexed with a different model — use "Regenerate Mismatched" to update them.
+								</p>
+							{/if}
+							<div class="flex flex-wrap gap-2">
+								<Button
+									type="button"
+									class="self-start w-auto"
+									onclick={() => generateEmbeddingBatch(false)}
+									disabled={embeddingInProgress || !canGenerateEmbeddings}
+								>
+									{embeddingInProgress ? 'Generating Embeddings...' : 'Generate Embeddings'}
+								</Button>
+								{#if (embeddingIndex.mismatched || 0) > 0}
+									<Button
+										type="button"
+										class="self-start w-auto"
+										onclick={() => generateEmbeddingBatch(true)}
+										disabled={embeddingInProgress || !canRegenerateMismatched}
+									>
+										Regenerate Mismatched
+									</Button>
+								{/if}
+							</div>
 							{#if embeddingBatchResult}
 								<p class="text-sm">
 									Processed: {embeddingBatchResult.processed}, Failed: {embeddingBatchResult.failed},


### PR DESCRIPTION
- Fixed: Switching embedding providers (OpenAI → Gemini → Ollama) no longer breaks semantic search — recipes indexed with the old model are now detected and excluded from results rather than flooding every query (#388)                                                                         
- Fixed: Admin site settings now shows a warning and a "Regenerate Mismatched" button when recipes exist with embeddings from a previous model, allowing a full re-index after a provider switch (#388)  