### PR TITLE
Fix e2e test button selector for recipe edit form

### DIFF
--- a/src/tests/e2e/admin-seed.spec.js
+++ b/src/tests/e2e/admin-seed.spec.js
@@ -179,7 +179,7 @@ test('fresh install admin seed, login, and page smoke tests', async ({ page }, t
 		await page.waitForURL('**/edit**', { timeout: 15000 })
 
 		// Wait for the form to be ready
-		const submitButton = page.getByRole('button', { name: 'Update Recipe' }).first()
+		const submitButton = page.getByRole('button', { name: 'Update' }).first()
 		await expect(submitButton).toBeVisible({ timeout: 15000 })
 
 		// Make a small change to the notes field


### PR DESCRIPTION
## Release Notes

- Fixed: E2e test was looking for 'Update Recipe' button which doesn't exist — corrected to 'Update'.