### PR TITLE
Fix stale AI model defaults and surface real LLM errors

### DIFF
--- a/src/lib/components/recipe/RecipeForm.svelte
+++ b/src/lib/components/recipe/RecipeForm.svelte
@@ -171,7 +171,7 @@
 		} catch (err) {
 			console.error('Ingredient cleanup failed:', err)
 			errorMessage = err.message || ''
-			errorCode = err.code || 'recipeForm.msg.cleanIngredientsFailed'
+			errorCode = err.code || (errorMessage ? null : 'recipeForm.msg.cleanIngredientsFailed')
 			ingredientsBeforeClean = null // Clear on failure
 		} finally {
 			cleaningIngredients = false
@@ -229,7 +229,7 @@
 		} catch (err) {
 			console.error('Direction summarization failed:', err)
 			errorMessage = err.message || ''
-			errorCode = err.code || 'recipeForm.msg.summarizeDirectionsFailed'
+			errorCode = err.code || (errorMessage ? null : 'recipeForm.msg.summarizeDirectionsFailed')
 			directionsBeforeSummarize = null // Clear on failure
 		} finally {
 			cleaningDirections = false
@@ -322,7 +322,7 @@
 		} catch (err) {
 			console.error('Recipe translation failed:', err)
 			errorMessage = err.message || ''
-			errorCode = err.code || 'recipeForm.msg.translateFailed'
+			errorCode = err.code || (errorMessage ? null : 'recipeForm.msg.translateFailed')
 		} finally {
 			translatingRecipe = false
 		}
@@ -364,7 +364,7 @@
 		} catch (err) {
 			console.error('Recipe image generation failed:', err)
 			errorMessage = err.message || ''
-			errorCode = err.code || 'recipeForm.msg.imageGenerateFailed'
+			errorCode = err.code || (errorMessage ? null : 'recipeForm.msg.imageGenerateFailed')
 		} finally {
 			generatingRecipeImage = false
 		}
@@ -401,7 +401,7 @@
 		} catch (err) {
 			console.error('Nutrition cleanup failed:', err)
 			errorMessage = err.message || ''
-			errorCode = err.code || 'recipeForm.msg.cleanNutritionFailed'
+			errorCode = err.code || (errorMessage ? null : 'recipeForm.msg.cleanNutritionFailed')
 			nutritionBeforeClean = null
 		} finally {
 			cleaningNutrition = false
@@ -453,7 +453,7 @@
 		} catch (err) {
 			console.error('Tips generation failed:', err)
 			errorMessage = err.message || ''
-			errorCode = err.code || 'recipeForm.msg.addTipsFailed'
+			errorCode = err.code || (errorMessage ? null : 'recipeForm.msg.addTipsFailed')
 			notesBeforeTips = null
 		} finally {
 			addingTips = false

--- a/src/lib/utils/ai.js
+++ b/src/lib/utils/ai.js
@@ -264,7 +264,7 @@ async function invokeLLM({ provider, model, type, messages }) {
 		env.LLM_API_ENGINE_TEXT ||
 		providerDefaults.text ||
 		fallbackDefaults.text ||
-		'gpt-4o-mini'
+		'gpt-5.6-luna'
 	const defaultImageModel =
 		env.LLM_IMAGE_MODEL ||
 		env.LLM_API_ENGINE_IMAGE ||

--- a/src/lib/utils/llmModels.js
+++ b/src/lib/utils/llmModels.js
@@ -49,18 +49,17 @@ export const providers = providerMeta.map((provider) => ({
 // Text models by provider - fast/cheap models for simple text processing
 export const textModels = {
 	openai: [
-		{ value: 'gpt-4o-mini', label: 'GPT-4o Mini (Recommended)' },
-		{ value: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo (Cheapest)' },
-		{ value: 'gpt-4o', label: 'GPT-4o (Higher quality)' }
+		{ value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna (Recommended, cheapest)' },
+		{ value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra (Higher quality)' }
 	],
 	anthropic: [
-		{ value: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku (Recommended)' },
-		{ value: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet' }
+		{ value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5 (Recommended)' },
+		{ value: 'claude-sonnet-5', label: 'Claude Sonnet 5 (Higher quality)' }
 	],
 	google: [
-		{ value: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash (Recommended)' },
-		{ value: 'gemini-1.5-flash', label: 'Gemini 1.5 Flash' },
-		{ value: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro (Higher quality)' }
+		{ value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash (Recommended)' },
+		{ value: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite (Cheapest)' },
+		{ value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro (Higher quality)' }
 	],
 	ollama: [
 		{ value: 'llama3.2', label: 'Llama 3.2' },
@@ -74,17 +73,17 @@ export const textModels = {
 // Ollama doesn't reliably support vision
 export const imageModels = {
 	openai: [
-		{ value: 'gpt-4o-mini', label: 'GPT-4o Mini (Recommended)' },
-		{ value: 'gpt-4o', label: 'GPT-4o (Higher quality)' }
+		{ value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna (Recommended, cheapest)' },
+		{ value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra (Higher quality)' }
 	],
 	anthropic: [
-		{ value: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet (Recommended)' },
-		{ value: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku' }
+		{ value: 'claude-sonnet-5', label: 'Claude Sonnet 5 (Recommended)' },
+		{ value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5' }
 	],
 	google: [
-		{ value: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash (Recommended)' },
-		{ value: 'gemini-1.5-flash', label: 'Gemini 1.5 Flash' },
-		{ value: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro (Higher quality)' }
+		{ value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash (Recommended)' },
+		{ value: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite (Cheapest)' },
+		{ value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro (Higher quality)' }
 	],
 	ollama: [] // Ollama vision support is inconsistent
 }

--- a/src/lib/utils/parse/compatibility/llm.js
+++ b/src/lib/utils/parse/compatibility/llm.js
@@ -30,7 +30,7 @@ function resolveCompatibilityModel(provider, model, env = process.env) {
 		env.LLM_API_ENGINE_TEXT ||
 		getDefaultModelsForProvider(provider)?.text ||
 		getDefaultModelsForProvider('openai')?.text ||
-		'gpt-4o-mini'
+		'gpt-5.6-luna'
 	)
 }
 

--- a/src/routes/api/recipe/[uid]/image/generate/+server.js
+++ b/src/routes/api/recipe/[uid]/image/generate/+server.js
@@ -125,6 +125,6 @@ export async function POST({ request, locals, params }) {
 				{ status: 429 }
 			)
 		}
-		return json({ error: message, code: 'recipeForm.msg.imageGenerateFailed' }, { status: 500 })
+		return json({ error: message }, { status: 500 })
 	}
 }

--- a/src/routes/api/recipe/cleanup/+server.js
+++ b/src/routes/api/recipe/cleanup/+server.js
@@ -230,9 +230,6 @@ Return format:
 				{ status: 429 }
 			)
 		}
-		return json(
-			{ error: 'Failed to clean up content.', code: 'recipeForm.msg.cleanupFailed' },
-			{ status: 500 }
-		)
+		return json({ error: err.message || 'Failed to clean up content.' }, { status: 500 })
 	}
 }

--- a/src/routes/api/recipe/parse/+server.js
+++ b/src/routes/api/recipe/parse/+server.js
@@ -52,9 +52,6 @@ export async function POST({ request, locals }) {
 		return json({ ...recipe, _source: 'AI', _status: 'complete' })
 	} catch (err) {
 		console.error('Text parse API failed:', err)
-		return json(
-			{ error: 'Failed to parse recipe.', code: 'recipeNew.msg.parseFailed' },
-			{ status: 500 }
-		)
+		return json({ error: err.message || 'Failed to parse recipe.' }, { status: 500 })
 	}
 }

--- a/src/routes/api/recipe/parse/image/+server.js
+++ b/src/routes/api/recipe/parse/image/+server.js
@@ -67,9 +67,6 @@ export async function POST({ request, locals }) {
 		return json({ ...recipe, _source: 'AI', _status: 'complete' })
 	} catch (err) {
 		console.error('Image parsing failed:', err)
-		return json(
-			{ error: 'Image parsing failed', code: 'recipeNew.msg.imageParseFailed' },
-			{ status: 500 }
-		)
+		return json({ error: err.message || 'Image parsing failed' }, { status: 500 })
 	}
 }

--- a/src/routes/api/recipe/translate/+server.js
+++ b/src/routes/api/recipe/translate/+server.js
@@ -39,9 +39,6 @@ export async function POST({ request, locals }) {
 		return json({ recipe: response })
 	} catch (err) {
 		console.error('Translate API failed:', err)
-		return json(
-			{ error: 'Failed to translate recipe.', code: 'recipeForm.msg.translateFailed' },
-			{ status: 500 }
-		)
+		return json({ error: err.message || 'Failed to translate recipe.' }, { status: 500 })
 	}
 }

--- a/src/routes/user/[id]/(private)/options/admin/site/+page.svelte
+++ b/src/routes/user/[id]/(private)/options/admin/site/+page.svelte
@@ -548,7 +548,7 @@
 							type="text"
 							id="customTextModel"
 							label={$t('admin.site.customModel')}
-							placeholder="e.g. gpt-4o-2024-08-06"
+							placeholder="e.g. gpt-5.6-terra"
 							bind:value={customTextModel}
 						/>
 					{/if}
@@ -574,7 +574,7 @@
 								type="text"
 								id="customImageModel"
 								label={$t('admin.site.customModel')}
-								placeholder="e.g. claude-3-5-sonnet-20241022"
+								placeholder="e.g. claude-sonnet-5"
 								bind:value={customImageModel}
 							/>
 						{/if}

--- a/src/tests/ai.routes.test.js
+++ b/src/tests/ai.routes.test.js
@@ -171,7 +171,7 @@ describe('API Routes - /api/recipe/parse', () => {
 			const data = await response.json()
 
 			expect(response.status).toBe(500)
-			expect(data.error).toContain('Failed to parse')
+			expect(data.error).toContain('LLM API error')
 		})
 	})
 })

--- a/src/tests/compatibility.test.js
+++ b/src/tests/compatibility.test.js
@@ -262,7 +262,7 @@ describe('compatibility LLM config resolution', () => {
 			})
 		).toEqual({
 			provider: 'openai',
-			model: 'gpt-4o-mini'
+			model: 'gpt-5.6-luna'
 		})
 	})
 })

--- a/src/tests/image.routes.test.js
+++ b/src/tests/image.routes.test.js
@@ -231,6 +231,6 @@ describe('API Routes - /api/recipe/[uid]/image/generate', () => {
 		const data = await response.json()
 
 		expect(response.status).toBe(500)
-		expect(data.code).toBe('recipeForm.msg.imageGenerateFailed')
+		expect(data.error).toBe('Provider unavailable')
 	})
 })


### PR DESCRIPTION
## Summary
- Replaced retired/soon-to-retire default model IDs across the Google, Anthropic, and OpenAI catalogs (`gemini-2.0-flash` and `gemini-1.5-*` were fully shut down by Google; both `claude-3-5-haiku/sonnet-20241022` snapshots are retired by Anthropic; `gpt-3.5-turbo`/`gpt-4o` are being phased out by OpenAI) with current GA models: `gemini-2.5-flash` family, `claude-haiku-4-5-20251001` / `claude-sonnet-5`, `gpt-5.6-luna` / `gpt-5.6-terra`.
- AI action failures (translate, cleanup, parse, image parse, image generation) now surface the real upstream error message in the UI toast instead of a generic canned string, so the next time a provider retires a model it's diagnosable from the app instead of only from server logs.

## Test plan
- [x] `pnpm test` — all 619 tests pass (3 tests updated to match new default models / error messages)
- [x] `pnpm lint` on changed files (pre-existing unrelated warnings on 3 files verified via `git stash` comparison)
- [ ] Manually confirm AI parsing/translation/cleanup works against a configured Google/Anthropic/OpenAI key
- [ ] If Admin → Site Settings has a saved custom `gemini-2.0-flash`/`claude-3-5-*`/etc. value, re-select the new default there after deploy (DB override takes precedence over code defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)